### PR TITLE
build(swagger-ui): add Subresource Integrity hashes to CDN assets

### DIFF
--- a/src/azure_functions_openapi/swagger_ui.py
+++ b/src/azure_functions_openapi/swagger_ui.py
@@ -15,6 +15,16 @@ logger = logging.getLogger(__name__)
 _SWAGGER_UI_DIST_VERSION = "5.32.4"
 _SWAGGER_UI_CDN_BASE = f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{_SWAGGER_UI_DIST_VERSION}"
 
+# Subresource Integrity (SRI) hashes for the pinned CDN assets. The browser
+# refuses to execute/apply a resource whose content does not match, so a CDN
+# compromise or a repointed version tag cannot serve altered assets.
+#
+# Regenerate on every ``_SWAGGER_UI_DIST_VERSION`` bump, e.g.:
+#   curl -sSL "$BASE/swagger-ui.css" | openssl dgst -sha384 -binary | openssl base64 -A
+#   curl -sSL "$BASE/swagger-ui-bundle.js" | openssl dgst -sha384 -binary | openssl base64 -A
+_SWAGGER_UI_CSS_SRI = "sha384-AHNbXeU7DPcgcihnwKYc3FOT0hTfhEwVFc2JRxxF5S/mplUdt/7G1g6nIblzENrX"
+_SWAGGER_UI_BUNDLE_SRI = "sha384-FgJpbEfGqpFeiFJh0+HNvyohx84XMd+IwgPyxJxjuDFMHVYmoFqrDEJNrVFexwA0"
+
 
 def render_swagger_ui(
     title: str = "API Documentation",
@@ -87,11 +97,15 @@ def render_swagger_ui(
         <title>{safe_title}</title>
         <link rel="stylesheet"
               type="text/css"
+              integrity="{_SWAGGER_UI_CSS_SRI}"
+              crossorigin="anonymous"
               href="{_SWAGGER_UI_CDN_BASE}/swagger-ui.css" />
       </head>
       <body>
         <div id="swagger-ui"></div>
-        <script src="{_SWAGGER_UI_CDN_BASE}/swagger-ui-bundle.js"></script>
+        <script src="{_SWAGGER_UI_CDN_BASE}/swagger-ui-bundle.js"
+                integrity="{_SWAGGER_UI_BUNDLE_SRI}"
+                crossorigin="anonymous"></script>
         <script nonce="{nonce}">
           // Enhanced security configuration
           const ui = SwaggerUIBundle({{

--- a/tests/test_swagger_ui.py
+++ b/tests/test_swagger_ui.py
@@ -26,3 +26,25 @@ def test_render_swagger_ui_pins_swagger_ui_dist_version() -> None:
     assert b"https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.4/swagger-ui.css" in body
     assert b"https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.4/swagger-ui-bundle.js" in body
     assert b"https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui" not in body
+
+
+def test_render_swagger_ui_sets_subresource_integrity() -> None:
+    """CDN <script>/<link> tags carry SRI + crossorigin so a compromised or
+    repointed CDN asset cannot execute in the browser."""
+    # Given
+    from azure_functions_openapi.swagger_ui import (
+        _SWAGGER_UI_BUNDLE_SRI,
+        _SWAGGER_UI_CSS_SRI,
+    )
+
+    response = render_swagger_ui()
+    body = response.get_body().decode()
+
+    # Then
+    # Both pinned assets are hardened with a sha384 SRI hash and CORS.
+    assert _SWAGGER_UI_CSS_SRI.startswith("sha384-")
+    assert _SWAGGER_UI_BUNDLE_SRI.startswith("sha384-")
+    assert f'integrity="{_SWAGGER_UI_CSS_SRI}"' in body
+    assert f'integrity="{_SWAGGER_UI_BUNDLE_SRI}"' in body
+    # crossorigin is mandatory for SRI validation to run against a CDN.
+    assert body.count('crossorigin="anonymous"') >= 2


### PR DESCRIPTION
## Summary
- Add `integrity="sha384-…"` + `crossorigin="anonymous"` to the two jsDelivr CDN assets (`swagger-ui.css`, `swagger-ui-bundle.js`) served by `render_swagger_ui`, so a CDN compromise or repointed version tag cannot execute altered assets in the browser.
- Store the SRI hashes as module constants next to the pinned `_SWAGGER_UI_DIST_VERSION`, with a documented regen command for version bumps.
- Add a regression test asserting both assets carry a `sha384-` integrity hash and `crossorigin="anonymous"`.

## Verification
- `hatch run pytest` — all pass, coverage 95.57% (≥95% gate).
- `make lint` / `make typecheck` — clean.

Closes #512