### PR TITLE
docs(readme): add azure-functions-logging companion callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
 
 > **Want runtime validation too? (optional)** `@openapi` documents your Pydantic models — it does not parse or validate requests at runtime. If you also want automatic request parsing, consistent `400`/`422` error responses, and response-model enforcement, layer [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python)'s `@validate_http` on the **same** Pydantic models. It is an optional companion, not a dependency — this package works fully on its own. See the [validation README](https://github.com/yeongseon/azure-functions-validation-python#readme) for details, or a full runnable example that pairs both on one resource: [Full Stack CRUD API](https://github.com/yeongseon/azure-functions-cookbook-python/tree/main/examples/apis-and-ingress/full_stack_crud_api).
 
+> **Want structured logging too? (optional)** Pair your documented endpoints with [`azure-functions-logging`](https://github.com/yeongseon/azure-functions-logging-python) for structured, correlation-aware logs and observability. It attaches request/response context to every log line without changing your `@openapi` contracts. Like validation, it is an optional companion, not a dependency — this package works fully on its own. See the [logging README](https://github.com/yeongseon/azure-functions-logging-python#readme) for details.
+
 <details>
 <summary>Wire up the spec + Swagger UI endpoints (openapi.json / openapi.yaml / docs)</summary>
 


### PR DESCRIPTION
## Summary
- Add a prose **companion callout** for `azure-functions-logging`, placed immediately after the existing `azure-functions-validation` callout in the Quick Start.
- Matches the validation callout's tone/format and frames logging as an **optional companion, not a dependency** — this package works fully on its own.
- Links the [logging README](https://github.com/yeongseon/azure-functions-logging-python#readme).

## Why
`azure-functions-logging` previously appeared only in the Ecosystem table, with no prose promotion in the companion flow. This adds the missing callout so the validation → logging companion story is complete (toolkit promotion plan item A-4).

## Out of scope
- No change to the Ecosystem table (logging row already exists).
- No runtime coupling to `azure-functions-logging`.

Closes #520