### PR TITLE
ci(pins): update canonical azure/login pin to v3.0.2

### DIFF
--- a/tools/lint_release_workflows.py
+++ b/tools/lint_release_workflows.py
@@ -42,7 +42,7 @@ CANONICAL_ACTIONS: dict[str, tuple[str, str]] = {
     # renovate: datasource=github-tags depName=actions/setup-python versioning=github-tags
     "actions/setup-python": ("5fda3b95a4ea91299a34e894583c3862153e4b97", "v7.0.0"),
     # renovate: datasource=github-tags depName=azure/login versioning=github-tags
-    "azure/login": ("f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca", "v3.0.1"),
+    "azure/login": ("7ddb5af1ef8758cf1353cf3b42f940aee27ba21c", "v3.0.2"),
     # renovate: datasource=github-tags depName=actions/upload-artifact versioning=github-tags
     "actions/upload-artifact": ("ea165f8d65b6e75b540449e92b4886f43607fa02", "v4"),
     # renovate: datasource=github-tags depName=actions/download-artifact versioning=github-tags


### PR DESCRIPTION
## Problem
Every lane of every PR is currently red on `test_release_workflow_pins::test_repo_release_workflows_are_clean`:

```
e2e-azure.yml:53: azure/login pinned to ...v3.0.2; expected canonical ...v3.0.1
```

Dependabot #524 bumped `azure/login` to **v3.0.2** (`7ddb5af`) across the workflows, but the canonical SHA map in `tools/lint_release_workflows.py` still pinned **v3.0.1** (`f5d393a`). The lint tool enforces a single canonical SHA for gate workflows, so the mismatch fails the guard test on **all** lanes — blocking CI repo-wide.

## Fix
Realign the canonical entry (line 45) with the bumped pin:
```python
"azure/login": ("7ddb5af1ef8758cf1353cf3b42f940aee27ba21c", "v3.0.2"),
```
Verified all `azure/login` references in `.github/workflows/` already use `7ddb5af` (v3.0.2), and `test_release_workflow_pins.py` passes locally.

## Notes
- Unblocks all other open PRs (including #525, the 2.x lane fix).