### PR TITLE
ci(branch-naming): allow build/ branch prefix

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -152,6 +152,7 @@ jobs:
               /^refactor\/.+$/,
               /^test\/.+$/,
               /^chore\/.+$/,
+              /^build\/.+$/,
               /^ci\/.+$/,
               /^codex\/.+$/,
               /^main$/
@@ -169,6 +170,7 @@ jobs:
                 - refactor/<description>
                 - test/<description>
                 - chore/<description>
+                - build/<description>
                 - ci/<description>
                 - codex/<description>
                 - main`);
@@ -192,5 +194,5 @@ jobs:
               owner,
               repo,
               issue_number: prNumber,
-              body: 'Warning: branch naming validation failed\n\nYour branch name `' + branchName + '` does not follow our naming conventions.\n\nPlease rename your branch to follow one of these patterns:\n- `feat/<description>` for new features\n- `fix/<description>` for bug fixes\n- `docs/<description>` for documentation changes\n- `refactor/<description>` for refactoring\n- `test/<description>` for test changes\n- `chore/<description>` for maintenance tasks\n- `ci/<description>` for CI/CD changes\n- `codex/<description>` for Codex-generated changes\n\nTo rename your branch:\n1. `git checkout ' + branchName + '`\n2. `git branch -m feat/your-new-branch-name`\n3. `git push origin --delete ' + branchName + '`\n4. `git push origin feat/your-new-branch-name`\n\nOnce you have renamed the branch, please update the PR head branch.'
+              body: 'Warning: branch naming validation failed\n\nYour branch name `' + branchName + '` does not follow our naming conventions.\n\nPlease rename your branch to follow one of these patterns:\n- `feat/<description>` for new features\n- `fix/<description>` for bug fixes\n- `docs/<description>` for documentation changes\n- `refactor/<description>` for refactoring\n- `test/<description>` for test changes\n- `chore/<description>` for maintenance tasks\n- `ci/<description>` for CI/CD changes\n- `build/<description>` for build/dependency changes\n- `codex/<description>` for Codex-generated changes\n\nTo rename your branch:\n1. `git checkout ' + branchName + '`\n2. `git branch -m feat/your-new-branch-name`\n3. `git push origin --delete ' + branchName + '`\n4. `git push origin feat/your-new-branch-name`\n\nOnce you have renamed the branch, please update the PR head branch.'
             });


### PR DESCRIPTION
## Context
`AGENTS.md` lists `build:` as a valid Conventional-Commit prefix, but the `branch-naming-validation` job in `stale.yml` only permitted `dependabot/ feat/ fix/ docs/ refactor/ test/ chore/ ci/ codex/`. This rejected legitimate build/dependency PRs whose branches use the `build/` prefix (e.g. #516 swagger-ui SRI, #518 dependabot cooldown).

## Change
- Add `/^build\/.+$/` to the allowed branch-name patterns.
- Add `build/<description>` to both the `setFailed` guidance and the PR comment body.

## Acceptance Checklist
- [x] `build/` branches pass branch-naming-validation
- [x] Failure messages document the `build/` prefix

## References
- Unblocks #516, #518