### PR TITLE
feat(deps): lift azure-functions <2.0.0 cap on Python 3.13+

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -77,31 +77,38 @@ jobs:
         env:
           CODECOV_RETRIES: 3
 
-  # azure-functions 2.x compatibility proof lane (issue #488), following the
-  # sibling proof-lane pattern (azure-functions-validation #351 /
-  # azure-functions-langgraph #350). This is a SINGLE representative 2.x lane,
-  # not a matrix: it installs the package, then deliberately overrides the
-  # pyproject `<2.0.0` cap to pull `azure-functions>=2,<3` on Python 3.13 and
-  # runs the full quality suite against the 2.x SDK.
+  # azure-functions 2.x compatibility proof lane (issues #488 / #528),
+  # following the sibling proof-lane pattern (azure-functions-validation #351 /
+  # azure-functions-langgraph #350). It installs the package from a WHEEL, then
+  # pulls `azure-functions>=2,<3` and runs the full quality suite against the
+  # 2.x SDK on real Python 3.13 AND 3.14 interpreters.
   #
-  # Gating decision: this lane runs on every PR as a VISIBLE compatibility
-  # signal, but it is intentionally NOT a required check — the runtime cap
-  # stays `<2.0.0` until 2.x is certified on real Azure via e2e-azure.yml, so
-  # making this blocking before that certification would gate merges on an
-  # uncertified runtime. Promote it to a required check via branch protection
-  # once the cap is lifted. azure-functions 2.x declares Requires-Python
-  # >=3.13, so this lane pins Python 3.13.
+  # Why a wheel + dedicated job (not the main matrix): the hatch `default` env is
+  # pinned to Python 3.10 in pyproject, so every cell of the `test` matrix runs
+  # Python 3.10 at runtime regardless of its `python-version`. Only this
+  # non-hatch, wheel-installed lane genuinely exercises 3.13/3.14, which is
+  # exactly where azure-functions 2.x (Requires-Python >=3.13) is installable.
+  #
+  # Gating: this lane runs on every PR as a VISIBLE compatibility signal. The
+  # pyproject cap is interpreter-aware (2.x is allowed on Python 3.13+), and the
+  # two version-pin guard tests are likewise interpreter-aware, so they run
+  # (not deselected) and actively prove 2.x is permitted on 3.13+. Promote to a
+  # required check via branch protection once real-Azure certification lands.
   azure-functions-2x:
-    name: azure-functions 2.x compat (Py 3.13)
+    name: azure-functions 2.x compat (Py ${{ matrix.python-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13", "3.14"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Set up Python 3.13
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
 
       - name: Build wheel
         # Prove 2.x against a WHEEL-installed build, not an editable/source
@@ -134,14 +141,11 @@ jobs:
         # shadow the installed wheel with the source tree. We drop `src` (so the
         # wheel-installed package is genuinely exercised) but keep the repo root
         # `.` on the path, because several tests import the `examples` package.
-        #
-        # Two version-pin POLICY guards are deselected: they assert the SDK is
-        # `<2.0.0` and therefore fail by design under this deliberate 2.x
-        # override. Every other test — including the `FunctionBuilder._function`
-        # private-attribute tripwires in these same files — still runs, which is
-        # exactly what proves the adapter surface holds under azure-functions 2.x.
+        # All version-pin guards are now interpreter-aware: on Python 3.13+ they
+        # assert only the >=1.21.0 floor (the <2.0.0 ceiling is lifted per issue
+        # #528), so they RUN here and actively prove 2.x is permitted. The
+        # `FunctionBuilder._function` private-attribute tripwires also run,
+        # proving the adapter surface holds under azure-functions 2.x.
         run: |
-          pytest tests/ --no-cov -q -o "pythonpath=." \
-            --deselect tests/test_sdk_compat.py::test_installed_azure_functions_version_meets_pin \
-            --deselect tests/test_sdk_compat_adapter.py::test_installed_sdk_is_within_supported_matrix
+          pytest tests/ --no-cov -q -o "pythonpath=."
 

--- a/README.md
+++ b/README.md
@@ -176,13 +176,25 @@ azure-functions-openapi
 
 This package discovers routes, methods, and handlers from the `azure-functions` SDK through a single isolated adapter (`azure_functions_openapi.adapters`). Discovery is **public-API-first**: it enumerates via the public, idempotent `FunctionBuilder.build()` and reads everything else through public `Function` accessors (`get_function_name` / `get_user_function` / `get_bindings` / `is_http_function`). The adapter never calls the non-idempotent `FunctionApp.get_functions()`. The **one** unavoidable private token — `app._function_builders`, which has no public substitute for enumeration — lives exclusively in the adapter and is covered by a mandatory guard test. We validate the package against an explicit matrix in CI. See [issue #258](https://github.com/yeongseon/azure-functions-openapi-python/issues/258) and [issue #327](https://github.com/yeongseon/azure-functions-openapi-python/issues/327) for background.
 
-| `azure-functions` | Python 3.10 | Python 3.11 | Python 3.12 | Python 3.13 | Python 3.14 |
-| ----------------- | :---------: | :---------: | :---------: | :---------: | :---------: |
-| `1.21.0` (floor)  | ✅ tested   |             |             |             |             |
-| `1.24.0`          | ✅ tested   |             |             |             |             |
-| `latest` (`<2.0`) | ✅ tested   | ✅ tested   | ✅ tested   | ✅ tested   | ✅ tested   |
+| `azure-functions`  | Python 3.10 | Python 3.11 | Python 3.12 | Python 3.13 | Python 3.14 |
+| ------------------ | :---------: | :---------: | :---------: | :---------: | :---------: |
+| `1.21.0` (floor)   | ✅ tested   |             |             |             |             |
+| `1.24.0`           | ✅ tested   |             |             |             |             |
+| `latest 1.x`       | ✅ tested   | ✅ tested   | ✅ tested   |             |             |
+| `2.x` (`>=2,<3`)   |             |             |             | ✅ tested   | ✅ tested   |
 
-The version pin in `pyproject.toml` is `azure-functions>=1.21.0,<2.0.0`. The floor is `1.21.0` because earlier releases return `None` from `FunctionBuilder.__call__` (breaking direct invocation of decorated handlers in tests and CLI extraction). If you need a newer SDK, please open an issue — the ceiling is intentional because `azure-functions` 2.x drops support for Python < 3.13 and has not yet been validated against `@openapi`.
+The version pin in `pyproject.toml` is interpreter-aware:
+`azure-functions>=1.21.0,<2.0.0` on Python < 3.13, and `azure-functions>=1.21.0`
+(no upper cap) on Python 3.13+. The floor is `1.21.0` because earlier releases
+return `None` from `FunctionBuilder.__call__` (breaking direct invocation of
+decorated handlers in tests and CLI extraction). The split exists because
+`azure-functions` 2.x drops support for Python < 3.13, so the 2.x line is only
+installable — and only offered — on Python 3.13+. The 2.x path is proven by a
+dedicated wheel-based compatibility matrix in CI (real Python 3.13 and 3.14
+interpreters) and is being certified on real Azure. See
+[issue #528](https://github.com/yeongseon/azure-functions-openapi-python/issues/528)
+and [issue #488](https://github.com/yeongseon/azure-functions-openapi-python/issues/488)
+for the cap-lift work.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ decorated handlers in tests and CLI extraction). The split exists because
 `azure-functions` 2.x drops support for Python < 3.13, so the 2.x line is only
 installable — and only offered — on Python 3.13+. The 2.x path is proven by a
 dedicated wheel-based compatibility matrix in CI (real Python 3.13 and 3.14
-interpreters) and is being certified on real Azure. See
+interpreters). Real-Azure certification of the 2.x path is a required
+follow-up, not yet complete. See
 [issue #528](https://github.com/yeongseon/azure-functions-openapi-python/issues/528)
 and [issue #488](https://github.com/yeongseon/azure-functions-openapi-python/issues/488)
 for the cap-lift work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,9 @@ dependencies = [
     # interpreter: Python < 3.13 stays capped at <2.0.0 (2.x is uninstallable
     # there), while Python >= 3.13 is allowed onto the 2.x line. The 2.x path is
     # proven by the wheel-based "azure-functions 2.x compat" matrix in
-    # ci-test.yml (real Python 3.13/3.14 interpreters) and certified on real
-    # Azure via e2e-azure.yml. See issue #528 (cap-lift) and #488 (compat lane).
+    # ci-test.yml (real Python 3.13/3.14 interpreters). Real-Azure certification
+    # of the 2.x path (via e2e-azure.yml) is a required follow-up, tracked by
+    # issue #528 (cap-lift); see also #488 (compat lane).
     "azure-functions>=1.21.0,<2.0.0; python_version < '3.13'",
     "azure-functions>=1.21.0; python_version >= '3.13'",
     "pydantic>=2.0,<3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,14 @@ classifiers = [
 ]
 
 dependencies = [
-    # Ceiling is intentional: azure-functions 2.x drops Python < 3.13 and is not
-    # yet certified against @openapi. Cap-lift criteria: (1) the non-blocking
-    # "azure-functions 2.x compat (Py 3.13)" lane in ci-test.yml is green, and
-    # (2) 2.x is certified on real Azure via e2e-azure.yml. Lifting the cap is a
-    # separate follow-up; do not raise it here. See issue #488.
-    "azure-functions>=1.21.0,<2.0.0",
+    # azure-functions 2.x drops Python < 3.13, so the constraint is split by
+    # interpreter: Python < 3.13 stays capped at <2.0.0 (2.x is uninstallable
+    # there), while Python >= 3.13 is allowed onto the 2.x line. The 2.x path is
+    # proven by the wheel-based "azure-functions 2.x compat" matrix in
+    # ci-test.yml (real Python 3.13/3.14 interpreters) and certified on real
+    # Azure via e2e-azure.yml. See issue #528 (cap-lift) and #488 (compat lane).
+    "azure-functions>=1.21.0,<2.0.0; python_version < '3.13'",
+    "azure-functions>=1.21.0; python_version >= '3.13'",
     "pydantic>=2.0,<3.0",
     "PyYAML",
 ]

--- a/tests/test_sdk_compat.py
+++ b/tests/test_sdk_compat.py
@@ -1,9 +1,11 @@
 # tests/test_sdk_compat.py
 """SDK shape sanity tests for azure-functions.
 
-These tests assert that the azure-functions SDK internals we depend on —
-namely ``FunctionBuilder._function._func`` and ``FunctionBuilder._function._bindings``
-— are present and usable in the currently installed SDK.
+These tests assert that the azure-functions SDK internals we depend on are
+present and usable in the currently installed SDK. The adapter and decorator
+now reach binding/handler metadata through the public ``FunctionBuilder`` /
+``Function`` accessors, but the tripwires below still pin the private
+``FunctionBuilder._function`` shape as an early break-glass signal.
 
 They act as an early-warning tripwire in CI: any SDK release that removes,
 renames, or restructures these private attributes will fail here loudly
@@ -16,6 +18,7 @@ Companion issue: https://github.com/yeongseon/azure-functions-openapi-python/iss
 from __future__ import annotations
 
 import importlib.metadata as _metadata
+import sys
 
 import azure.functions as func
 from azure.functions.decorators.function_app import FunctionBuilder
@@ -27,10 +30,12 @@ from azure_functions_openapi.decorator import (
 
 
 def test_installed_azure_functions_version_meets_pin() -> None:
-    """The installed SDK must satisfy the ``>=1.19.0,<2.0.0`` pin from pyproject.toml.
+    """The installed SDK must satisfy the interpreter-aware pin from pyproject.toml.
 
-    This catches accidental downgrades in dev environments and confirms that
-    the CI matrix installed the version it intended to.
+    Below Python 3.13 the pin caps ``azure-functions`` at ``<2.0.0`` (the 2.x
+    line drops those interpreters). On Python 3.13+ the ``<2.0.0`` cap is lifted
+    (issue #528), so only the ``>=1.19.0`` floor is enforced. This catches
+    accidental downgrades and confirms the CI matrix installed what it intended.
     """
     installed = _metadata.version("azure-functions")
     major_minor = tuple(int(p) for p in installed.split(".")[:2])
@@ -38,18 +43,24 @@ def test_installed_azure_functions_version_meets_pin() -> None:
         f"azure-functions {installed} is below the >=1.19.0 pin declared in "
         "pyproject.toml. Update the pin or bump the installed version."
     )
-    assert major_minor < (2, 0), (
-        f"azure-functions {installed} is above the <2.0.0 pin declared in "
-        "pyproject.toml. See issue #258 before widening the ceiling."
-    )
+    if sys.version_info < (3, 13):
+        assert major_minor < (2, 0), (
+            f"azure-functions {installed} reached the 2.x line on Python "
+            f"{sys.version_info.major}.{sys.version_info.minor}, but the pin caps "
+            "it at <2.0.0 below Python 3.13. See issue #528 before widening the "
+            "ceiling on older interpreters."
+        )
 
 
 def test_function_builder_exposes_private_attributes_we_depend_on() -> None:
     """Direct existence assertion for ``FunctionBuilder._function._func``
     and ``._bindings``.
 
-    ``decorator._resolve_metadata_target`` reads ``_function._func`` and
-    ``decorator._extract_binding_hints`` reads ``_function._bindings``.
+    Historically ``decorator._resolve_metadata_target`` read ``_function._func``
+    and ``decorator._extract_binding_hints`` read ``_function._bindings``
+    directly. Both now route through the public adapter accessors, so this test
+    is a pure break-glass tripwire: it keeps watching the private
+    ``_function._func`` / ``._bindings`` shape so any SDK reshuffle is caught
     If the SDK renames/removes either attribute, this test fails immediately
     with an actionable message pointing at issue #258.
     """

--- a/tests/test_sdk_compat.py
+++ b/tests/test_sdk_compat.py
@@ -34,13 +34,13 @@ def test_installed_azure_functions_version_meets_pin() -> None:
 
     Below Python 3.13 the pin caps ``azure-functions`` at ``<2.0.0`` (the 2.x
     line drops those interpreters). On Python 3.13+ the ``<2.0.0`` cap is lifted
-    (issue #528), so only the ``>=1.19.0`` floor is enforced. This catches
+    (issue #528), so only the ``>=1.21.0`` floor is enforced. This catches
     accidental downgrades and confirms the CI matrix installed what it intended.
     """
     installed = _metadata.version("azure-functions")
     major_minor = tuple(int(p) for p in installed.split(".")[:2])
-    assert major_minor >= (1, 19), (
-        f"azure-functions {installed} is below the >=1.19.0 pin declared in "
+    assert major_minor >= (1, 21), (
+        f"azure-functions {installed} is below the >=1.21.0 pin declared in "
         "pyproject.toml. Update the pin or bump the installed version."
     )
     if sys.version_info < (3, 13):
@@ -60,7 +60,7 @@ def test_function_builder_exposes_private_attributes_we_depend_on() -> None:
     and ``decorator._extract_binding_hints`` read ``_function._bindings``
     directly. Both now route through the public adapter accessors, so this test
     is a pure break-glass tripwire: it keeps watching the private
-    ``_function._func`` / ``._bindings`` shape so any SDK reshuffle is caught
+    ``_function._func`` / ``._bindings`` shape so any SDK reshuffle is caught.
     If the SDK renames/removes either attribute, this test fails immediately
     with an actionable message pointing at issue #258.
     """

--- a/tests/test_sdk_compat_adapter.py
+++ b/tests/test_sdk_compat_adapter.py
@@ -2,19 +2,20 @@
 
 After the adapter isolation (#325), all Azure Functions SDK discovery flows
 through :mod:`azure_functions_openapi.adapters.azure_functions`. This module
-pins that contract against the *installed* SDK so the CI matrix
-(``azure-functions`` 1.21 → latest ``<2.0``, Python 3.10–3.14) proves the
-package works on every supported line before the ``<2.0.0`` ceiling is ever
-relaxed.
+pins that contract against the *installed* SDK so the CI matrix proves the
+package works on every supported line: ``azure-functions`` 1.21 → latest 1.x
+on Python 3.10–3.12, and the 2.x line on Python 3.13+ (the wheel-based compat
+matrix in ci-test.yml).
 
-Verified support matrix (enforced by CI; see ``pyproject.toml`` pin
-``azure-functions>=1.21.0,<2.0.0`` and the README "SDK Compatibility" table):
+Verified support matrix (enforced by CI; see the interpreter-aware
+``pyproject.toml`` pin and the README "SDK Compatibility" table):
 
     azure-functions | Python
     --------------- | ----------------------------
     1.21.0 (floor)  | 3.10
     1.24.0          | 3.10
-    latest (<2.0)   | 3.10, 3.11, 3.12, 3.13, 3.14
+    latest (<2.0)   | 3.10, 3.11, 3.12
+    2.x (>=2,<3)    | 3.13, 3.14
 
 Three guarantees are asserted here:
 
@@ -34,6 +35,7 @@ Three guarantees are asserted here:
 from __future__ import annotations
 
 import importlib.metadata as _metadata
+import sys
 from typing import Any
 from unittest import mock
 
@@ -60,7 +62,12 @@ def _make_app() -> Any:
 
 
 def test_installed_sdk_is_within_supported_matrix() -> None:
-    """The installed SDK must satisfy the ``>=1.21.0,<2.0.0`` pin."""
+    """The installed SDK must satisfy the interpreter-aware pin.
+
+    Below Python 3.13 the pin is ``>=1.21.0,<2.0.0``. On Python 3.13+ the
+    ``<2.0.0`` ceiling is lifted (issue #528) and the wheel-based 2.x compat
+    matrix proves the adapter holds, so only the ``>=1.21.0`` floor is enforced.
+    """
     installed = _metadata.version("azure-functions")
     major_minor = tuple(int(p) for p in installed.split(".")[:2])
     assert major_minor >= (1, 21), (
@@ -68,10 +75,12 @@ def test_installed_sdk_is_within_supported_matrix() -> None:
         "pyproject.toml. The floor exists because earlier releases return None "
         "from FunctionBuilder.__call__. See issue #327."
     )
-    assert major_minor < (2, 0), (
-        f"azure-functions {installed} is above the <2.0.0 ceiling. The ceiling "
-        "is only widened after the #327 compatibility matrix is green."
-    )
+    if sys.version_info < (3, 13):
+        assert major_minor < (2, 0), (
+            f"azure-functions {installed} is above the <2.0.0 ceiling on Python "
+            f"{sys.version_info.major}.{sys.version_info.minor}. The ceiling is "
+            "only lifted on Python 3.13+ (issue #528)."
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the install-blocking `azure-functions>=1.21.0,<2.0.0` cap for Python 3.13+ so users can install `azure-functions==2.3.0` alongside this package. Follow-up to the now-closed #488 (compat lane), tracked by #528.

- **Interpreter-aware pin** (`pyproject.toml`): `azure-functions>=1.21.0,<2.0.0; python_version < '3.13'` and `azure-functions>=1.21.0; python_version >= '3.13'`. Python <3.13 stays capped (2.x drops those interpreters); 3.13+ is allowed onto 2.x.
- **Version-aware guard tests**: `test_installed_azure_functions_version_meets_pin` and `test_installed_sdk_is_within_supported_matrix` now enforce the `<2.0.0` ceiling only below Python 3.13, and enforce the `>=1.21.0` floor everywhere.
- **CI**: generalized the wheel-based `azure-functions-2x` proof lane into a real **Python 3.13 + 3.14** matrix against `azure-functions>=2,<3`, and **removed the two `--deselect`s** — the guards are now interpreter-aware, so they run and actively prove 2.x is permitted on 3.13+.
- **Docs**: refreshed the README "SDK Compatibility" table (adds a `2.x` row for 3.13/3.14) and replaced the "ceiling is intentional" rationale; fixed a stale `test_sdk_compat.py` docstring (the decorator no longer reads `_function._func`/`_bindings` directly).

## Why the wheel lane (not the main matrix)

The hatch `default` env is pinned to `python = "3.10"`, so **every cell of the `test` matrix runs Python 3.10 at runtime** regardless of its `python-version` (verified against a live CI run: the `test (3.13, latest)` cell reports `Python 3.10.20`). Only the non-hatch, wheel-installed lane genuinely exercises 3.13/3.14 — exactly where `azure-functions` 2.x (Requires-Python >=3.13) is installable.

## Verification

- Full suite locally on Py 3.10 + af 1.25.0: coverage **95.44%** (>= 95). Version-aware guards pass (the `<2.0.0` branch is exercised).
- `ruff check` / `ruff format --check` / `mypy` clean on changed files.
- The one local failure (`test_version_matches_distribution_metadata`) is a stale hatch-env metadata artifact (0.19.1 installed vs 0.24.0 source), unrelated to this change; it self-heals when CI rebuilds the editable install.

## Out of scope (deferred)

- Real-Azure E2E certification on a Python 3.13 runtime (parameterize `infra/main.bicep` `linuxFxVersion`, extend `e2e-azure.yml`). The Done definition in #528 requires this before the release is certified; it is a follow-up step per the agreed scope for this PR.

Refs #528, #488