### PR TITLE
feat(schema): infer 200 response from handler return type

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -13,7 +13,10 @@ from azure_functions_openapi._endpoint_contract import (
     SUPPORTED_ENDPOINT_VERSIONS,
 )
 from azure_functions_openapi._warnings import WarningCode
-from azure_functions_openapi.decorator import register_openapi_metadata
+from azure_functions_openapi.decorator import (
+    _infer_response_from_return,
+    register_openapi_metadata,
+)
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
 from azure_functions_openapi.registry import (
     OpenAPIRegistry,
@@ -146,10 +149,15 @@ def _merge_parameters(
 
 
 def _models_conflict(existing: dict[str, Any], discovered: dict[str, Any]) -> bool:
+    # An inferred response (P1-A return-type inference) is the lowest-precedence
+    # source, so it never conflicts with discovered validation metadata — the
+    # latter simply supersedes it in :func:`_merge_into_existing`.
+    response_inferred = bool(existing.get("_response_inferred"))
     existing_response = existing.get("response_model")
     discovered_response = discovered.get("response_model")
     if (
-        existing_response is not None
+        not response_inferred
+        and existing_response is not None
         and discovered_response is not None
         and existing_response is not discovered_response
     ):
@@ -171,7 +179,11 @@ def _models_conflict(existing: dict[str, Any], discovered: dict[str, Any]) -> bo
 
     existing_response = existing.get("response") or {}
     discovered_response = discovered.get("response") or {}
-    if isinstance(existing_response, dict) and isinstance(discovered_response, dict):
+    if (
+        not response_inferred
+        and isinstance(existing_response, dict)
+        and isinstance(discovered_response, dict)
+    ):
         for status, detail in discovered_response.items():
             if status in existing_response and existing_response[status] != detail:
                 return True
@@ -182,6 +194,16 @@ def _models_conflict(existing: dict[str, Any], discovered: dict[str, Any]) -> bo
 def _merge_into_existing(existing: dict[str, Any], discovered: dict[str, Any]) -> None:
     if _models_conflict(existing, discovered):
         raise OpenAPISpecConfigError("Conflicting validation and OpenAPI models for endpoint")
+
+    # Return-type inference (P1-A) is the lowest-precedence response source. When
+    # discovered validation/explicit metadata carries any response, it supersedes
+    # the inferred one entirely rather than gap-filling around it.
+    if existing.get("_response_inferred") and (
+        discovered.get("response_model") or discovered.get("response")
+    ):
+        existing["response_model"] = None
+        existing["response"] = {}
+        existing.pop("_response_inferred", None)
 
     if not existing.get("request_body") and discovered.get("request_body"):
         existing["request_body"] = discovered["request_body"]
@@ -576,6 +598,18 @@ def scan_endpoint_metadata(
             ) or function_name
             path = _normalize_path(entry_route or raw_route, entry_name, route_prefix)
 
+        # Return-type inference (P1-A): for a bare ``@app.route`` handler with no
+        # ``@openapi`` entry and no validation enrichment, infer the 200 response
+        # from the handler's return annotation. Gated off when a canonical entry
+        # exists (decorator-time inference already ran), when validation
+        # enrichment is present (higher precedence), or under version skew (keep
+        # the degraded bare op observable). Computed once — it does not vary per
+        # method.
+        inferred_response_model: Any = None
+        inferred_response: dict[int | str, dict[str, Any]] | None = None
+        if canonical_target is None and endpoint_hints is None and not endpoint_skew:
+            inferred_response_model, inferred_response = _infer_response_from_return(handler)
+
         for method in methods:
             endpoint_key = f"{method}::{path}"
             entry_skew: set[WarningCode] = {WarningCode.VERSION_SKEW} if endpoint_skew else set()
@@ -636,9 +670,14 @@ def scan_endpoint_metadata(
                         _tag_skew(canonical_target, entry_skew)
                         continue
                     if not entry_skew:
-                        # Plain binding with neither @openapi nor enrichment nor
-                        # skew: nothing to register.
-                        continue
+                        if inferred_response_model is None and inferred_response is None:
+                            # Plain binding with neither @openapi nor enrichment
+                            # nor skew nor an inferable return type: nothing to
+                            # register.
+                            continue
+                        # Return-type inference (P1-A): fall through past the
+                        # lock to register the inferred response as a standalone
+                        # binding-derived operation below.
                     # Endpoint namespace present but rejected (skew) with no
                     # canonical @openapi entry: fall through to register a bare
                     # binding-derived operation below and tag the skew, so the
@@ -701,6 +740,21 @@ def scan_endpoint_metadata(
                     parameters=discovered.get("parameters") or None,
                     registry=reg,
                 )
+            elif inferred_response_model is not None or inferred_response is not None:
+                # Standalone operation materialized purely from return-type
+                # inference (P1-A). Tag it ``_response_inferred`` so a later scan
+                # carrying validation/explicit metadata supersedes it.
+                register_openapi_metadata(
+                    path=path,
+                    method=method,
+                    response_model=inferred_response_model,
+                    response=cast("dict[int, dict[str, Any]] | None", inferred_response or None),
+                    registry=reg,
+                )
+                with reg.lock:
+                    inferred_entry = reg.get(endpoint_key)
+                    if inferred_entry is not None:
+                        inferred_entry["_response_inferred"] = True
             else:
                 # Bare binding-derived operation for an endpoint-skew handler: no
                 # enrichment was consumed, but the operation is materialized so

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -273,7 +273,7 @@ def _normalize_unified_responses(
 def _infer_response_from_return(
     func: Callable[..., Any],
 ) -> tuple[type[BaseModel] | None, dict[int | str, dict[str, Any]] | None]:
-    """Infer a 200 response from a handler's return annotation (P1-A, #TBD).
+    """Infer a 200 response from a handler's return annotation (P1-A).
 
     Gap-filling only. Returns ``(model, None)`` when the return annotation is a
     Pydantic ``BaseModel`` subclass, or ``(None, {200: <Response Object>})`` when
@@ -302,9 +302,9 @@ def _infer_response_from_return(
 
     hint = hints.get("return")
     if hint is None:
-        # No return annotation, or annotated as ``None`` (``get_type_hints``
-        # maps a bare ``None`` return to ``type(None)``, handled by the
-        # not-documentable fall-through below).
+        # No return annotation at all. (An explicit ``-> None`` annotation is
+        # instead resolved to ``type(None)`` by ``get_type_hints`` and falls
+        # through to the not-documentable branch below.)
         return None, None
 
     if _is_pydantic_model(hint):

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -7,7 +7,17 @@ from http import HTTPStatus
 import logging
 import re
 import types
-from typing import Any, Callable, Literal, TypeGuard, TypeVar, Union, cast, get_origin
+from typing import (
+    Any,
+    Callable,
+    Literal,
+    TypeGuard,
+    TypeVar,
+    Union,
+    cast,
+    get_origin,
+    get_type_hints,
+)
 
 from pydantic import BaseModel
 
@@ -260,6 +270,59 @@ def _normalize_unified_responses(
     return normalized
 
 
+def _infer_response_from_return(
+    func: Callable[..., Any],
+) -> tuple[type[BaseModel] | None, dict[int | str, dict[str, Any]] | None]:
+    """Infer a 200 response from a handler's return annotation (P1-A, #TBD).
+
+    Gap-filling only. Returns ``(model, None)`` when the return annotation is a
+    Pydantic ``BaseModel`` subclass, or ``(None, {200: <Response Object>})`` when
+    it is a supported container/union shorthand (e.g. ``list[User]``,
+    ``Optional[User]``) — the raw type is stored and resolved to a schema at
+    spec-generation time, exactly like an explicit ``responses=`` shorthand.
+
+    Returns ``(None, None)`` when the return annotation is absent, unresolved, or
+    not a documentable schema type (``None``/``NoneType``, ``Any``,
+    ``func.HttpResponse``, bare ``str``/``int``, ...). Inference is the
+    lowest-precedence source: callers apply it only when the user supplied no
+    explicit ``responses=``, and validation/explicit metadata supersedes it
+    during scan-time reconciliation.
+
+    All annotation introspection is wrapped so a handler with unresolved forward
+    references (e.g. under ``from __future__ import annotations``) never breaks
+    decoration or spec generation — on any failure inference simply yields
+    nothing.
+    """
+    try:
+        hints = get_type_hints(func, include_extras=True)
+    except Exception:
+        # Unresolved forward refs / stringized annotations / exotic objects:
+        # never let inference raise. Emit nothing instead.
+        return None, None
+
+    hint = hints.get("return")
+    if hint is None:
+        # No return annotation, or annotated as ``None`` (``get_type_hints``
+        # maps a bare ``None`` return to ``type(None)``, handled by the
+        # not-documentable fall-through below).
+        return None, None
+
+    if _is_pydantic_model(hint):
+        return hint, None
+
+    if _is_supported_shorthand_generic(hint):
+        return None, {
+            200: {
+                "description": _default_response_description(200),
+                "content": {"application/json": {"schema": hint}},
+            }
+        }
+
+    # Not a documentable schema type (NoneType, Any, func.HttpResponse, bare
+    # scalars, unsupported generics): leave the response undocumented.
+    return None, None
+
+
 def openapi(
     # ── basic metadata ───────────────────────────────────────────
     summary: str = "",
@@ -478,6 +541,21 @@ def openapi(
                         "'responses' must be either a Pydantic BaseModel subclass or a dictionary."
                     )
 
+            # ── return-type inference (P1-A) ─────────────────────────────
+            # Lowest-precedence gap-fill: only when the user supplied no
+            # explicit ``responses=``. An inferred response is marked so that
+            # scan-time validation/explicit metadata can supersede it (Oracle
+            # precedence: explicit > validation > inference).
+            response_inferred = False
+            if responses is None:
+                inferred_model, inferred_response = _infer_response_from_return(metadata_func)
+                if inferred_model is not None:
+                    resolved_response_model = inferred_model
+                    response_inferred = True
+                elif inferred_response is not None:
+                    resolved_response = inferred_response
+                    response_inferred = True
+
             resolved_querystring_model: type[BaseModel] | None = None
             resolved_querystring_schema: dict[str, Any] | None = None
             if querystring is not None:
@@ -534,6 +612,10 @@ def openapi(
                         "request_body_required": request_body_required,
                         "response_model": resolved_response_model,
                         "response": resolved_response or {},
+                        # Marks ``response``/``response_model`` as return-type
+                        # inferred (P1-A) so scan-time reconciliation lets
+                        # validation/explicit metadata supersede it.
+                        "_response_inferred": response_inferred,
                         # ── querystring (OpenAPI 3.2) ────────────────────────
                         "querystring_model": resolved_querystring_model,
                         "querystring_schema": resolved_querystring_schema,

--- a/tests/test_return_type_inference.py
+++ b/tests/test_return_type_inference.py
@@ -1,0 +1,321 @@
+"""Return-type inference (P1-A).
+
+Covers the Phase 1 feature that infers the 200 response schema from a handler's
+return annotation, at both decorator-time (``@openapi``) and scan-time (bare
+``@app.route`` with no ``@openapi``). Inference is strictly the lowest-precedence
+response source: explicit ``responses=`` and validation/enrichment metadata both
+supersede it, and it must never raise on unresolved annotations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_openapi.bridge import (
+    _HANDLER_METADATA_ATTR,
+    _merge_into_existing,
+    _models_conflict,
+    scan_endpoint_metadata,
+)
+from azure_functions_openapi.decorator import (
+    _infer_response_from_return,
+    clear_openapi_registry,
+    get_openapi_registry,
+    openapi,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+class User(BaseModel):
+    id: int
+    name: str
+
+
+class Other(BaseModel):
+    ok: bool
+
+
+# ---------------------------------------------------------------------------
+# _infer_response_from_return (unit)
+# ---------------------------------------------------------------------------
+
+
+def test_infer_basemodel_return() -> None:
+    def handler(req: Any) -> User:  # pragma: no cover - body never executed
+        ...
+
+    model, response = _infer_response_from_return(handler)
+    assert model is User
+    assert response is None
+
+
+def test_infer_container_generic_return() -> None:
+    def handler(req: Any) -> list[User]:  # pragma: no cover - body never executed
+        ...
+
+    model, response = _infer_response_from_return(handler)
+    assert model is None
+    assert response is not None
+    assert response[200]["content"]["application/json"]["schema"] == list[User]
+
+
+def test_infer_optional_return_is_union_shorthand() -> None:
+    def handler(req: Any) -> Optional[User]:  # pragma: no cover
+        ...
+
+    model, response = _infer_response_from_return(handler)
+    assert model is None
+    assert response is not None
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [None, "str", "int", "dict", "Any"],
+    ids=["none", "str", "int", "bare-dict", "any"],
+)
+def test_infer_non_documentable_returns_nothing(annotation: str | None) -> None:
+    ns: dict[str, Any] = {"Any": Any}
+    if annotation is None:
+
+        def handler(req: Any):  # pragma: no cover
+            ...
+    else:
+        src = f"def handler(req):\n    ...\nhandler.__annotations__ = {{'return': {annotation}}}"
+        exec(src, ns)  # noqa: S102 - constructs a handler with a scalar return
+        handler = ns["handler"]
+
+    model, response = _infer_response_from_return(handler)
+    assert model is None
+    assert response is None
+
+
+def test_infer_forward_ref_never_raises() -> None:
+    # Simulate ``from __future__ import annotations`` leaving an unresolved
+    # stringized forward reference: get_type_hints() raises NameError, which the
+    # helper must swallow and yield nothing rather than break spec generation.
+    def handler(req: Any):  # pragma: no cover
+        ...
+
+    handler.__annotations__ = {"return": "ThisTypeDoesNotExistAnywhere"}
+
+    model, response = _infer_response_from_return(handler)
+    assert model is None
+    assert response is None
+
+
+# ---------------------------------------------------------------------------
+# Decorator-time inference
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_infers_response_model_from_return() -> None:
+    @openapi(summary="Get a user")
+    def get_user(req: Any) -> User:  # pragma: no cover
+        ...
+
+    entry = get_openapi_registry()["get_user"]
+    assert entry["response_model"] is User
+    assert entry["_response_inferred"] is True
+
+
+def test_decorator_infers_array_response_from_return() -> None:
+    @openapi(summary="List users")
+    def list_users(req: Any) -> list[User]:  # pragma: no cover
+        ...
+
+    entry = get_openapi_registry()["list_users"]
+    assert entry["response_model"] is None
+    schema = entry["response"][200]["content"]["application/json"]["schema"]
+    assert schema == list[User]
+    assert entry["_response_inferred"] is True
+
+
+def test_explicit_responses_win_over_inference() -> None:
+    # Oracle precedence: explicit > validation > inference. An explicit
+    # responses= must never be overridden by the return annotation.
+    @openapi(summary="Create", responses=Other)
+    def create(req: Any) -> User:  # pragma: no cover
+        ...
+
+    entry = get_openapi_registry()["create"]
+    assert entry["response_model"] is Other
+    assert entry["_response_inferred"] is False
+
+
+def test_no_annotation_infers_nothing() -> None:
+    @openapi(summary="Bare")
+    def bare(req: Any):  # pragma: no cover
+        ...
+
+    entry = get_openapi_registry()["bare"]
+    assert entry["response_model"] is None
+    assert entry["response"] == {}
+    assert entry["_response_inferred"] is False
+
+
+# ---------------------------------------------------------------------------
+# Scan-time inference (zero-decorator @app.route)
+# ---------------------------------------------------------------------------
+
+
+class _MockBinding:
+    def __init__(self, route: str, methods: list[str]) -> None:
+        self.route = route
+        self.methods = methods
+        self.type = "httpTrigger"
+
+
+class _MockFunction:
+    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
+        self._name = name
+        self._func = func
+        self._bindings = bindings
+
+    def get_function_name(self) -> str:
+        return self._name
+
+    def get_user_function(self) -> Any:
+        return self._func
+
+    def get_bindings(self) -> list[Any]:
+        return self._bindings
+
+    def is_http_function(self) -> bool:
+        return True
+
+
+class _MockBuilder:
+    def __init__(self, function: _MockFunction) -> None:
+        self._function = function
+
+    def build(self, auth_level: Any = None) -> _MockFunction:
+        return self._function
+
+
+class _MockApp:
+    def __init__(self, builders: list[_MockBuilder]) -> None:
+        self._function_builders = builders
+
+
+def _app_for(handler: Any, *, name: str, route: str, methods: list[str]) -> _MockApp:
+    fn = _MockFunction(name=name, func=handler, bindings=[_MockBinding(route, methods)])
+    return _MockApp([_MockBuilder(fn)])
+
+
+def test_scan_infers_array_response_for_bare_route() -> None:
+    def list_users(req: Any) -> list[User]:  # pragma: no cover
+        ...
+
+    scan_endpoint_metadata(_app_for(list_users, name="list_users", route="users", methods=["GET"]))
+
+    entry = get_openapi_registry()["get::/api/users"]
+    assert entry["_response_inferred"] is True
+    schema = entry["response"][200]["content"]["application/json"]["schema"]
+    assert schema == list[User]
+
+
+def test_scan_infers_response_model_for_bare_route() -> None:
+    def get_user(req: Any) -> User:  # pragma: no cover
+        ...
+
+    scan_endpoint_metadata(_app_for(get_user, name="get_user", route="users", methods=["GET"]))
+
+    entry = get_openapi_registry()["get::/api/users"]
+    assert entry["response_model"] is User
+    assert entry["_response_inferred"] is True
+
+
+def test_scan_bare_route_without_annotation_registers_nothing() -> None:
+    def ping(req: Any):  # pragma: no cover
+        ...
+
+    scan_endpoint_metadata(_app_for(ping, name="ping", route="ping", methods=["GET"]))
+
+    assert "get::/api/ping" not in get_openapi_registry()
+
+
+def test_scan_endpoint_enrichment_supersedes_inference() -> None:
+    # A handler carrying validation/enrichment metadata AND a return annotation:
+    # the enrichment (higher precedence) is used; inference is gated off.
+    def create_user(req: Any) -> User:  # pragma: no cover
+        ...
+
+    setattr(
+        create_user,
+        _HANDLER_METADATA_ATTR,
+        {
+            "endpoint": {
+                "version": 1,
+                "responses": {
+                    "200": {"schema": {"type": "object", "properties": {"ok": {"type": "boolean"}}}}
+                },
+            }
+        },
+    )
+
+    scan_endpoint_metadata(
+        _app_for(create_user, name="create_user", route="users", methods=["POST"])
+    )
+
+    entry = get_openapi_registry()["post::/api/users"]
+    # Enrichment response wins; the entry is not marked inferred.
+    assert entry.get("_response_inferred") is not True
+    assert entry["response"][200]["content"]["application/json"]["schema"] == {
+        "type": "object",
+        "properties": {"ok": {"type": "boolean"}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Merge precedence: validation supersedes an inferred response
+# ---------------------------------------------------------------------------
+
+
+def test_merge_validation_supersedes_inferred_response_model() -> None:
+    existing: dict[str, Any] = {
+        "response_model": User,
+        "response": {},
+        "_response_inferred": True,
+        "parameters": [],
+    }
+    discovered: dict[str, Any] = {"response_model": Other, "parameters": []}
+
+    # No conflict: inference always yields to discovered metadata.
+    assert _models_conflict(existing, discovered) is False
+    _merge_into_existing(existing, discovered)
+
+    assert existing["response_model"] is Other
+    assert "_response_inferred" not in existing
+
+
+def test_merge_validation_supersedes_inferred_response_dict() -> None:
+    existing: dict[str, Any] = {
+        "response_model": None,
+        "response": {200: {"description": "OK", "content": {"application/json": {"schema": User}}}},
+        "_response_inferred": True,
+        "parameters": [],
+    }
+    discovered: dict[str, Any] = {
+        "response": {
+            200: {
+                "description": "Validated",
+                "content": {"application/json": {"schema": {"type": "object"}}},
+            }
+        },
+        "parameters": [],
+    }
+
+    assert _models_conflict(existing, discovered) is False
+    _merge_into_existing(existing, discovered)
+
+    assert existing["response"][200]["description"] == "Validated"
+    assert "_response_inferred" not in existing

--- a/tests/test_return_type_inference.py
+++ b/tests/test_return_type_inference.py
@@ -51,7 +51,7 @@ class Other(BaseModel):
 
 def test_infer_basemodel_return() -> None:
     def handler(req: Any) -> User:  # pragma: no cover - body never executed
-        ...
+        raise NotImplementedError
 
     model, response = _infer_response_from_return(handler)
     assert model is User
@@ -60,7 +60,7 @@ def test_infer_basemodel_return() -> None:
 
 def test_infer_container_generic_return() -> None:
     def handler(req: Any) -> list[User]:  # pragma: no cover - body never executed
-        ...
+        raise NotImplementedError
 
     model, response = _infer_response_from_return(handler)
     assert model is None
@@ -70,7 +70,7 @@ def test_infer_container_generic_return() -> None:
 
 def test_infer_optional_return_is_union_shorthand() -> None:
     def handler(req: Any) -> Optional[User]:  # pragma: no cover
-        ...
+        raise NotImplementedError
 
     model, response = _infer_response_from_return(handler)
     assert model is None
@@ -85,9 +85,8 @@ def test_infer_optional_return_is_union_shorthand() -> None:
 def test_infer_non_documentable_returns_nothing(annotation: str | None) -> None:
     ns: dict[str, Any] = {"Any": Any}
     if annotation is None:
-
-        def handler(req: Any):  # pragma: no cover
-            ...
+        exec("def handler(req):\n    raise NotImplementedError", ns)  # noqa: S102
+        handler = ns["handler"]
     else:
         src = f"def handler(req):\n    ...\nhandler.__annotations__ = {{'return': {annotation}}}"
         exec(src, ns)  # noqa: S102 - constructs a handler with a scalar return
@@ -102,8 +101,8 @@ def test_infer_forward_ref_never_raises() -> None:
     # Simulate ``from __future__ import annotations`` leaving an unresolved
     # stringized forward reference: get_type_hints() raises NameError, which the
     # helper must swallow and yield nothing rather than break spec generation.
-    def handler(req: Any):  # pragma: no cover
-        ...
+    def handler(req: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
 
     handler.__annotations__ = {"return": "ThisTypeDoesNotExistAnywhere"}
 
@@ -120,7 +119,7 @@ def test_infer_forward_ref_never_raises() -> None:
 def test_decorator_infers_response_model_from_return() -> None:
     @openapi(summary="Get a user")
     def get_user(req: Any) -> User:  # pragma: no cover
-        ...
+        raise NotImplementedError
 
     entry = get_openapi_registry()["get_user"]
     assert entry["response_model"] is User
@@ -130,7 +129,7 @@ def test_decorator_infers_response_model_from_return() -> None:
 def test_decorator_infers_array_response_from_return() -> None:
     @openapi(summary="List users")
     def list_users(req: Any) -> list[User]:  # pragma: no cover
-        ...
+        raise NotImplementedError
 
     entry = get_openapi_registry()["list_users"]
     assert entry["response_model"] is None
@@ -144,7 +143,7 @@ def test_explicit_responses_win_over_inference() -> None:
     # responses= must never be overridden by the return annotation.
     @openapi(summary="Create", responses=Other)
     def create(req: Any) -> User:  # pragma: no cover
-        ...
+        raise NotImplementedError
 
     entry = get_openapi_registry()["create"]
     assert entry["response_model"] is Other
@@ -153,8 +152,8 @@ def test_explicit_responses_win_over_inference() -> None:
 
 def test_no_annotation_infers_nothing() -> None:
     @openapi(summary="Bare")
-    def bare(req: Any):  # pragma: no cover
-        ...
+    def bare(req: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
 
     entry = get_openapi_registry()["bare"]
     assert entry["response_model"] is None
@@ -213,7 +212,7 @@ def _app_for(handler: Any, *, name: str, route: str, methods: list[str]) -> _Moc
 
 def test_scan_infers_array_response_for_bare_route() -> None:
     def list_users(req: Any) -> list[User]:  # pragma: no cover
-        ...
+        raise NotImplementedError
 
     scan_endpoint_metadata(_app_for(list_users, name="list_users", route="users", methods=["GET"]))
 
@@ -225,7 +224,7 @@ def test_scan_infers_array_response_for_bare_route() -> None:
 
 def test_scan_infers_response_model_for_bare_route() -> None:
     def get_user(req: Any) -> User:  # pragma: no cover
-        ...
+        raise NotImplementedError
 
     scan_endpoint_metadata(_app_for(get_user, name="get_user", route="users", methods=["GET"]))
 
@@ -235,8 +234,8 @@ def test_scan_infers_response_model_for_bare_route() -> None:
 
 
 def test_scan_bare_route_without_annotation_registers_nothing() -> None:
-    def ping(req: Any):  # pragma: no cover
-        ...
+    def ping(req: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
 
     scan_endpoint_metadata(_app_for(ping, name="ping", route="ping", methods=["GET"]))
 
@@ -247,7 +246,7 @@ def test_scan_endpoint_enrichment_supersedes_inference() -> None:
     # A handler carrying validation/enrichment metadata AND a return annotation:
     # the enrichment (higher precedence) is used; inference is gated off.
     def create_user(req: Any) -> User:  # pragma: no cover
-        ...
+        raise NotImplementedError
 
     setattr(
         create_user,


### PR DESCRIPTION
## Context

Phase 1 of **P1-A (schema auto-generation enhancement)**: stop forcing developers to re-type information already expressed in their code. This PR infers the **200 response schema from a handler's return annotation**, the first and highest-priority automation in the P1-A plan.

- `def get_user(...) -> User:` → 200 body is the `User` schema (`$ref`)
- `def list_users(...) -> list[User]:` → 200 body is an array of `User`

Design was reviewed with the Oracle: **hybrid placement, default-on, failure-silent, inference is lowest precedence.**

## What changed

- **`decorator.py`** — new `_infer_response_from_return(func)` helper. Safe `get_type_hints(..., include_extras=True)` wrapped in `try/except` (unresolved forward refs under `from __future__ import annotations` never raise). Returns a `BaseModel`, a `{200: <Response Object>}` for supported container/union shorthands, or nothing for non-documentable returns (`None`/`NoneType`/`Any`/`func.HttpResponse`/bare scalars/unsupported generics). Runs only when `responses=` is omitted; stamps a `_response_inferred` marker.
- **`bridge.py`** — scan-time inference for **bare `@app.route`** handlers (zero-decorator UX), gated off when a `@openapi` entry, validation enrichment, or version-skew is present. `_merge_into_existing` / `_models_conflict` updated so validation/explicit metadata **supersedes** an inferred response without raising a false conflict.

**Precedence enforced:** explicit `@openapi(responses=...)` > `@validate_http` / enrichment metadata > return-type inference.

## Acceptance Checklist

- [x] `-> User` infers a 200 `$ref` response (decorator-time)
- [x] `-> list[User]` / `Optional[User]` infers array/union 200 response
- [x] Bare `@app.route` (no `@openapi`) infers via scan-time path
- [x] Explicit `responses=` and validation enrichment supersede inference
- [x] Non-documentable returns (`HttpResponse`, `None`, `Any`, bare scalars) infer nothing
- [x] Unresolved forward refs never raise during decoration or spec generation
- [x] 19 new regression tests; full suite green (818 passed)
- [x] Coverage 96% (≥95% gate); `ruff` + `mypy` clean

## Out of scope

- Phase 2: docstring → `summary`/`description` inference (follow-up PR).

## References

- P1-A schema auto-generation plan
- AGENTS.md working rules (coverage ≥95%, typed public APIs)