### PR TITLE
feat(schema): infer summary/description from handler docstring

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -14,6 +14,7 @@ from azure_functions_openapi._endpoint_contract import (
 )
 from azure_functions_openapi._warnings import WarningCode
 from azure_functions_openapi.decorator import (
+    _infer_doc_metadata,
     _infer_response_from_return,
     register_openapi_metadata,
 )
@@ -607,8 +608,11 @@ def scan_endpoint_metadata(
         # method.
         inferred_response_model: Any = None
         inferred_response: dict[int | str, dict[str, Any]] | None = None
+        inferred_summary = ""
+        inferred_description = ""
         if canonical_target is None and endpoint_hints is None and not endpoint_skew:
             inferred_response_model, inferred_response = _infer_response_from_return(handler)
+            inferred_summary, inferred_description = _infer_doc_metadata(handler)
 
         for method in methods:
             endpoint_key = f"{method}::{path}"
@@ -747,6 +751,8 @@ def scan_endpoint_metadata(
                 register_openapi_metadata(
                     path=path,
                     method=method,
+                    summary=inferred_summary,
+                    description=inferred_description,
                     response_model=inferred_response_model,
                     response=cast("dict[int, dict[str, Any]] | None", inferred_response or None),
                     registry=reg,

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -342,8 +342,8 @@ def _infer_doc_metadata(func: Callable[..., Any]) -> tuple[str, str]:
 
 def openapi(
     # ── basic metadata ───────────────────────────────────────────
-    summary: str = "",
-    description: str = "",
+    summary: str | None = None,
+    description: str | None = None,
     tags: list[str] | None = None,
     operation_id: str | None = None,
     # ── routing information ─────────────────────────────────────
@@ -420,9 +420,13 @@ def openapi(
     Parameters
     ----------
     summary:
-        Short description shown in Swagger UI.
+        Short description shown in Swagger UI. Defaults to ``None`` (unset),
+        in which case it is inferred from the handler docstring's first line;
+        pass ``""`` to explicitly suppress that inference.
     description:
-        Longer Markdown-enabled description.
+        Longer Markdown-enabled description. Defaults to ``None`` (unset), in
+        which case it is inferred from the handler docstring body; pass ``""``
+        to explicitly suppress that inference.
     tags:
         List of group tags.
     operation_id:
@@ -575,14 +579,19 @@ def openapi(
 
             # ── docstring inference (P1-A Phase 2) ───────────────────────
             # Lowest-precedence gap-fill, per field: only when the user gave
-            # no explicit ``summary=`` / ``description=``. The handler docstring's
-            # first line becomes the summary and the remainder the description.
-            effective_summary = summary
-            effective_description = description
-            if not summary or not description:
+            # no explicit ``summary=`` / ``description=``. ``None`` is the
+            # "unset" sentinel, so an explicit ``summary=""`` / ``description=""``
+            # is an intentional override and suppresses inference for that field.
+            # The handler docstring's first line becomes the summary and the
+            # remainder the description.
+            effective_summary = summary or ""
+            effective_description = description or ""
+            if summary is None or description is None:
                 inferred_summary, inferred_description = _infer_doc_metadata(metadata_func)
-                effective_summary = summary or inferred_summary
-                effective_description = description or inferred_description
+                if summary is None:
+                    effective_summary = inferred_summary
+                if description is None:
+                    effective_description = inferred_description
 
             resolved_querystring_model: type[BaseModel] | None = None
             resolved_querystring_schema: dict[str, Any] | None = None

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import collections.abc as _cabc
 from collections.abc import Mapping
 from http import HTTPStatus
+import inspect
 import logging
 import re
 import types
@@ -322,6 +323,22 @@ def _infer_response_from_return(
     # scalars, unsupported generics): leave the response undocumented.
     return None, None
 
+def _infer_doc_metadata(func: Callable[..., Any]) -> tuple[str, str]:
+    """Infer ``(summary, description)`` from a handler's docstring (P1-A Phase 2).
+
+    Gap-filling only and lowest precedence: the first non-empty line of the
+    (dedented) docstring becomes the ``summary`` and the remainder becomes the
+    ``description``. Callers apply each field only when the user supplied no
+    explicit value. A missing or blank docstring yields ``("", "")``.
+    """
+    doc = inspect.getdoc(func)
+    if not doc or not doc.strip():
+        return "", ""
+    lines = doc.strip().split("\n")
+    summary = lines[0].strip()
+    description = "\n".join(lines[1:]).strip()
+    return summary, description
+
 
 def openapi(
     # ── basic metadata ───────────────────────────────────────────
@@ -556,6 +573,17 @@ def openapi(
                     resolved_response = inferred_response
                     response_inferred = True
 
+            # ── docstring inference (P1-A Phase 2) ───────────────────────
+            # Lowest-precedence gap-fill, per field: only when the user gave
+            # no explicit ``summary=`` / ``description=``. The handler docstring's
+            # first line becomes the summary and the remainder the description.
+            effective_summary = summary
+            effective_description = description
+            if not summary or not description:
+                inferred_summary, inferred_description = _infer_doc_metadata(metadata_func)
+                effective_summary = summary or inferred_summary
+                effective_description = description or inferred_description
+
             resolved_querystring_model: type[BaseModel] | None = None
             resolved_querystring_schema: dict[str, Any] | None = None
             if querystring is not None:
@@ -591,8 +619,8 @@ def openapi(
                     registry_key,
                     {
                         # ── basic metadata ────────────────────────────────────────
-                        "summary": summary,
-                        "description": description,
+                        "summary": effective_summary,
+                        "description": effective_description,
                         "tags": validated_tags,
                         "operation_id": sanitized_operation_id,
                         # ── routing info ─────────────────────────────────────────

--- a/tests/_scan_helpers.py
+++ b/tests/_scan_helpers.py
@@ -1,0 +1,56 @@
+"""Shared scan-time test scaffolding for inference test modules.
+
+Minimal in-memory doubles for the ``azure-functions`` public discovery surface
+(``FunctionBuilder.build()`` + ``Function`` accessors + ``app._function_builders``)
+that ``scan_endpoint_metadata`` reads. Extracted here so return-type and
+docstring inference tests share one definition and scanner changes touch a
+single place.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class _MockBinding:
+    def __init__(self, route: str, methods: list[str]) -> None:
+        self.route = route
+        self.methods = methods
+        self.type = "httpTrigger"
+
+
+class _MockFunction:
+    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
+        self._name = name
+        self._func = func
+        self._bindings = bindings
+
+    def get_function_name(self) -> str:
+        return self._name
+
+    def get_user_function(self) -> Any:
+        return self._func
+
+    def get_bindings(self) -> list[Any]:
+        return self._bindings
+
+    def is_http_function(self) -> bool:
+        return True
+
+
+class _MockBuilder:
+    def __init__(self, function: _MockFunction) -> None:
+        self._function = function
+
+    def build(self, auth_level: Any = None) -> _MockFunction:
+        return self._function
+
+
+class _MockApp:
+    def __init__(self, builders: list[_MockBuilder]) -> None:
+        self._function_builders = builders
+
+
+def _app_for(handler: Any, *, name: str, route: str, methods: list[str]) -> _MockApp:
+    fn = _MockFunction(name=name, func=handler, bindings=[_MockBinding(route, methods)])
+    return _MockApp([_MockBuilder(fn)])

--- a/tests/test_docstring_inference.py
+++ b/tests/test_docstring_inference.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from _scan_helpers import _app_for
 from pydantic import BaseModel
 import pytest
 
@@ -151,53 +152,41 @@ def test_decorator_no_docstring_leaves_empty() -> None:
     assert entry["description"] == ""
 
 
+def test_explicit_empty_string_suppresses_docstring_inference() -> None:
+    # ``None`` is the "unset" sentinel; an explicit ``""`` is an intentional
+    # override and must NOT be back-filled from the docstring (#532 review).
+    @openapi(summary="", description="")
+    def get_user(req: Any) -> User:  # pragma: no cover
+        """Doc summary.
+
+        Doc description.
+        """
+        raise NotImplementedError
+
+    entry = get_openapi_registry()["get_user"]
+    assert entry["summary"] == ""
+    assert entry["description"] == ""
+
+
+def test_explicit_empty_summary_still_infers_description() -> None:
+    # Per-field sentinel: suppressing summary with ``""`` must not stop the
+    # description from being inferred (it was left as ``None``).
+    @openapi(summary="")
+    def get_user(req: Any) -> User:  # pragma: no cover
+        """Doc summary.
+
+        Doc description.
+        """
+        raise NotImplementedError
+
+    entry = get_openapi_registry()["get_user"]
+    assert entry["summary"] == ""
+    assert entry["description"] == "Doc description."
+
+
 # ---------------------------------------------------------------------------
 # Scan-time inference (zero-decorator @app.route)
 # ---------------------------------------------------------------------------
-
-
-class _MockBinding:
-    def __init__(self, route: str, methods: list[str]) -> None:
-        self.route = route
-        self.methods = methods
-        self.type = "httpTrigger"
-
-
-class _MockFunction:
-    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
-        self._name = name
-        self._func = func
-        self._bindings = bindings
-
-    def get_function_name(self) -> str:
-        return self._name
-
-    def get_user_function(self) -> Any:
-        return self._func
-
-    def get_bindings(self) -> list[Any]:
-        return self._bindings
-
-    def is_http_function(self) -> bool:
-        return True
-
-
-class _MockBuilder:
-    def __init__(self, function: _MockFunction) -> None:
-        self._function = function
-
-    def build(self, auth_level: Any = None) -> _MockFunction:
-        return self._function
-
-
-class _MockApp:
-    def __init__(self, builders: list[_MockBuilder]) -> None:
-        self._function_builders = builders
-
-
-def _app_for(handler: Any, *, name: str, route: str, methods: list[str]) -> _MockApp:
-    fn = _MockFunction(name=name, func=handler, bindings=[_MockBinding(route, methods)])
-    return _MockApp([_MockBuilder(fn)])
 
 
 def test_scan_infers_docstring_for_bare_route() -> None:

--- a/tests/test_docstring_inference.py
+++ b/tests/test_docstring_inference.py
@@ -1,0 +1,226 @@
+"""Docstring inference (P1-A Phase 2).
+
+Covers inferring ``summary``/``description`` from a handler's docstring at both
+decorator-time (``@openapi``) and scan-time (bare ``@app.route`` that also has a
+documentable return annotation). Docstring inference is per-field and the
+lowest-precedence source: an explicit ``summary=``/``description=`` always wins,
+and a missing/blank docstring infers nothing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_openapi.bridge import scan_endpoint_metadata
+from azure_functions_openapi.decorator import (
+    _infer_doc_metadata,
+    clear_openapi_registry,
+    get_openapi_registry,
+    openapi,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+class User(BaseModel):
+    id: int
+    name: str
+
+
+# ---------------------------------------------------------------------------
+# _infer_doc_metadata (unit)
+# ---------------------------------------------------------------------------
+
+
+def test_infer_summary_and_description_from_docstring() -> None:
+    def handler(req: Any) -> Any:  # pragma: no cover - body never executed
+        """Get a user.
+
+        Returns the user identified by the path id.
+        """
+        raise NotImplementedError
+
+    summary, description = _infer_doc_metadata(handler)
+    assert summary == "Get a user."
+    assert description == "Returns the user identified by the path id."
+
+
+def test_infer_single_line_docstring_has_empty_description() -> None:
+    def handler(req: Any) -> Any:  # pragma: no cover
+        """Ping the service."""
+        raise NotImplementedError
+
+    summary, description = _infer_doc_metadata(handler)
+    assert summary == "Ping the service."
+    assert description == ""
+
+
+def test_infer_no_docstring_yields_empty() -> None:
+    def handler(req: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    assert _infer_doc_metadata(handler) == ("", "")
+
+
+def test_infer_blank_docstring_yields_empty() -> None:
+    def handler(req: Any) -> Any:  # pragma: no cover
+        """ """
+        raise NotImplementedError
+
+    assert _infer_doc_metadata(handler) == ("", "")
+
+
+def test_infer_dedents_indented_body() -> None:
+    def handler(req: Any) -> Any:  # pragma: no cover
+        """Create a user.
+
+        Line one.
+        Line two.
+        """
+        raise NotImplementedError
+
+    summary, description = _infer_doc_metadata(handler)
+    assert summary == "Create a user."
+    assert description == "Line one.\nLine two."
+
+
+# ---------------------------------------------------------------------------
+# Decorator-time inference
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_infers_summary_and_description() -> None:
+    @openapi()
+    def get_user(req: Any) -> User:  # pragma: no cover
+        """Get a user.
+
+        Full description here.
+        """
+        raise NotImplementedError
+
+    entry = get_openapi_registry()["get_user"]
+    assert entry["summary"] == "Get a user."
+    assert entry["description"] == "Full description here."
+
+
+def test_explicit_summary_wins_but_description_is_inferred() -> None:
+    # Per-field gap fill: an explicit summary is kept while a missing
+    # description is still filled from the docstring body.
+    @openapi(summary="Explicit summary")
+    def get_user(req: Any) -> User:  # pragma: no cover
+        """Doc summary.
+
+        Doc description.
+        """
+        raise NotImplementedError
+
+    entry = get_openapi_registry()["get_user"]
+    assert entry["summary"] == "Explicit summary"
+    assert entry["description"] == "Doc description."
+
+
+def test_explicit_both_win_over_docstring() -> None:
+    @openapi(summary="S", description="D")
+    def get_user(req: Any) -> User:  # pragma: no cover
+        """Doc summary.
+
+        Doc description.
+        """
+        raise NotImplementedError
+
+    entry = get_openapi_registry()["get_user"]
+    assert entry["summary"] == "S"
+    assert entry["description"] == "D"
+
+
+def test_decorator_no_docstring_leaves_empty() -> None:
+    @openapi()
+    def bare(req: Any) -> User:  # pragma: no cover
+        raise NotImplementedError
+
+    entry = get_openapi_registry()["bare"]
+    assert entry["summary"] == ""
+    assert entry["description"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Scan-time inference (zero-decorator @app.route)
+# ---------------------------------------------------------------------------
+
+
+class _MockBinding:
+    def __init__(self, route: str, methods: list[str]) -> None:
+        self.route = route
+        self.methods = methods
+        self.type = "httpTrigger"
+
+
+class _MockFunction:
+    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
+        self._name = name
+        self._func = func
+        self._bindings = bindings
+
+    def get_function_name(self) -> str:
+        return self._name
+
+    def get_user_function(self) -> Any:
+        return self._func
+
+    def get_bindings(self) -> list[Any]:
+        return self._bindings
+
+    def is_http_function(self) -> bool:
+        return True
+
+
+class _MockBuilder:
+    def __init__(self, function: _MockFunction) -> None:
+        self._function = function
+
+    def build(self, auth_level: Any = None) -> _MockFunction:
+        return self._function
+
+
+class _MockApp:
+    def __init__(self, builders: list[_MockBuilder]) -> None:
+        self._function_builders = builders
+
+
+def _app_for(handler: Any, *, name: str, route: str, methods: list[str]) -> _MockApp:
+    fn = _MockFunction(name=name, func=handler, bindings=[_MockBinding(route, methods)])
+    return _MockApp([_MockBuilder(fn)])
+
+
+def test_scan_infers_docstring_for_bare_route() -> None:
+    def get_user(req: Any) -> User:  # pragma: no cover
+        """Get a user.
+
+        Scan-time description.
+        """
+        raise NotImplementedError
+
+    scan_endpoint_metadata(_app_for(get_user, name="get_user", route="users", methods=["GET"]))
+
+    entry = get_openapi_registry()["get::/api/users"]
+    assert entry["summary"] == "Get a user."
+    assert entry["description"] == "Scan-time description."
+
+
+def test_scan_bare_route_without_docstring_has_empty_metadata() -> None:
+    def get_user(req: Any) -> User:  # pragma: no cover
+        raise NotImplementedError
+
+    scan_endpoint_metadata(_app_for(get_user, name="get_user", route="users", methods=["GET"]))
+
+    entry = get_openapi_registry()["get::/api/users"]
+    assert entry["summary"] == ""
+    assert entry["description"] == ""

--- a/tests/test_return_type_inference.py
+++ b/tests/test_return_type_inference.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+from _scan_helpers import _app_for
 from pydantic import BaseModel
 import pytest
 
@@ -164,50 +165,6 @@ def test_no_annotation_infers_nothing() -> None:
 # ---------------------------------------------------------------------------
 # Scan-time inference (zero-decorator @app.route)
 # ---------------------------------------------------------------------------
-
-
-class _MockBinding:
-    def __init__(self, route: str, methods: list[str]) -> None:
-        self.route = route
-        self.methods = methods
-        self.type = "httpTrigger"
-
-
-class _MockFunction:
-    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
-        self._name = name
-        self._func = func
-        self._bindings = bindings
-
-    def get_function_name(self) -> str:
-        return self._name
-
-    def get_user_function(self) -> Any:
-        return self._func
-
-    def get_bindings(self) -> list[Any]:
-        return self._bindings
-
-    def is_http_function(self) -> bool:
-        return True
-
-
-class _MockBuilder:
-    def __init__(self, function: _MockFunction) -> None:
-        self._function = function
-
-    def build(self, auth_level: Any = None) -> _MockFunction:
-        return self._function
-
-
-class _MockApp:
-    def __init__(self, builders: list[_MockBuilder]) -> None:
-        self._function_builders = builders
-
-
-def _app_for(handler: Any, *, name: str, route: str, methods: list[str]) -> _MockApp:
-    fn = _MockFunction(name=name, func=handler, bindings=[_MockBinding(route, methods)])
-    return _MockApp([_MockBuilder(fn)])
 
 
 def test_scan_infers_array_response_for_bare_route() -> None:


### PR DESCRIPTION
## Summary

P1-A **Phase 2** (stacked on #530). Infers the operation `summary`/`description` from a handler's docstring so authors stop re-typing prose that already lives next to the code.

- First line of the docstring → `summary`; remaining lines → `description`.
- Applied at **decorator-time** (`@openapi`) and **scan-time** (bare `@app.route` that already materializes an operation via Phase 1 return-type inference).
- **Lowest precedence, per field:** explicit `summary=`/`description=` always win independently; a missing/blank docstring infers nothing. `inspect.getdoc` dedents nested docstrings.

## Precedence (unchanged, Oracle-reviewed)

explicit `@openapi` args > `@validate_http`/enrichment metadata > inference.

## Tests

New `tests/test_docstring_inference.py` (11 tests): unit helper, decorator-time, per-field explicit-wins, no/blank docstring, dedent, and scan-time bare-route. Full suite 829 passed / 29 skipped, coverage 95.69% (≥95% gate). `ruff check` + `mypy src tests` (strict) clean.

## Notes

- Stacked on #530 (`feat/infer-return-type-response`); GitHub will retarget to `main` once #530 merges.
- Scope: docstring only fills `summary`/`description`. Parameters/tags/examples stay author-authoritative (see #531).

Refs #531.