### PR TITLE
fix(bridge): register summary/description for docstring-only bare routes

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -674,14 +674,20 @@ def scan_endpoint_metadata(
                         _tag_skew(canonical_target, entry_skew)
                         continue
                     if not entry_skew:
-                        if inferred_response_model is None and inferred_response is None:
+                        if (
+                            inferred_response_model is None
+                            and inferred_response is None
+                            and not inferred_summary
+                            and not inferred_description
+                        ):
                             # Plain binding with neither @openapi nor enrichment
-                            # nor skew nor an inferable return type: nothing to
-                            # register.
+                            # nor skew nor an inferable return type nor a
+                            # docstring: nothing to register.
                             continue
-                        # Return-type inference (P1-A): fall through past the
-                        # lock to register the inferred response as a standalone
-                        # binding-derived operation below.
+                        # Return-type / docstring inference (P1-A): fall through
+                        # past the lock to register the inferred response and/or
+                        # summary/description as a standalone binding-derived
+                        # operation below.
                     # Endpoint namespace present but rejected (skew) with no
                     # canonical @openapi entry: fall through to register a bare
                     # binding-derived operation below and tag the skew, so the
@@ -744,7 +750,17 @@ def scan_endpoint_metadata(
                     parameters=discovered.get("parameters") or None,
                     registry=reg,
                 )
-            elif inferred_response_model is not None or inferred_response is not None:
+            elif (
+                inferred_response_model is not None
+                or inferred_response is not None
+                or inferred_summary
+                or inferred_description
+            ):
+                # Standalone operation materialized purely from return-type
+                # and/or docstring inference (P1-A). When a response was inferred,
+                # tag it ``_response_inferred`` so a later scan carrying
+                # validation/explicit metadata supersedes it. A docstring-only
+                # entry (no inferred response) carries no such tag.
                 # Standalone operation materialized purely from return-type
                 # inference (P1-A). Tag it ``_response_inferred`` so a later scan
                 # carrying validation/explicit metadata supersedes it.
@@ -757,10 +773,11 @@ def scan_endpoint_metadata(
                     response=cast("dict[int, dict[str, Any]] | None", inferred_response or None),
                     registry=reg,
                 )
-                with reg.lock:
-                    inferred_entry = reg.get(endpoint_key)
-                    if inferred_entry is not None:
-                        inferred_entry["_response_inferred"] = True
+                if inferred_response_model is not None or inferred_response is not None:
+                    with reg.lock:
+                        inferred_entry = reg.get(endpoint_key)
+                        if inferred_entry is not None:
+                            inferred_entry["_response_inferred"] = True
             else:
                 # Bare binding-derived operation for an endpoint-skew handler: no
                 # enrichment was consumed, but the operation is materialized so

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -323,6 +323,7 @@ def _infer_response_from_return(
     # scalars, unsupported generics): leave the response undocumented.
     return None, None
 
+
 def _infer_doc_metadata(func: Callable[..., Any]) -> tuple[str, str]:
     """Infer ``(summary, description)`` from a handler's docstring (P1-A Phase 2).
 

--- a/tests/test_docstring_inference.py
+++ b/tests/test_docstring_inference.py
@@ -1,8 +1,8 @@
 """Docstring inference (P1-A Phase 2).
 
 Covers inferring ``summary``/``description`` from a handler's docstring at both
-decorator-time (``@openapi``) and scan-time (bare ``@app.route`` that also has a
-documentable return annotation). Docstring inference is per-field and the
+decorator-time (``@openapi``) and scan-time (bare ``@app.route``, with or
+without a documentable return annotation). Docstring inference is per-field and
 lowest-precedence source: an explicit ``summary=``/``description=`` always wins,
 and a missing/blank docstring infers nothing.
 """
@@ -213,3 +213,40 @@ def test_scan_bare_route_without_docstring_has_empty_metadata() -> None:
     entry = get_openapi_registry()["get::/api/users"]
     assert entry["summary"] == ""
     assert entry["description"] == ""
+
+
+def test_scan_infers_docstring_for_bare_route_without_documentable_return() -> None:
+    # Regression (#534): a bare route whose return type is NOT documentable
+    # (a scalar here) still has a docstring — its summary/description must be
+    # registered, not silently dropped because no response was inferred.
+    def get_user(req: Any) -> str:  # pragma: no cover
+        """Get a user.
+
+        Docstring-only description.
+        """
+        raise NotImplementedError
+
+    scan_endpoint_metadata(_app_for(get_user, name="get_user", route="users", methods=["GET"]))
+
+    entry = get_openapi_registry()["get::/api/users"]
+    assert entry["summary"] == "Get a user."
+    assert entry["description"] == "Docstring-only description."
+    # No response was inferred, so the private supersession tag must be absent.
+    assert "_response_inferred" not in entry
+    assert not entry.get("response")
+    assert entry.get("response_model") is None
+
+
+def test_scan_infers_docstring_for_unannotated_bare_route() -> None:
+    # Regression (#534): a bare route with no return annotation at all but a
+    # docstring must still register its summary/description.
+    def get_user(req: Any):  # type: ignore[no-untyped-def]  # pragma: no cover
+        """Ping."""
+        raise NotImplementedError
+
+    scan_endpoint_metadata(_app_for(get_user, name="get_user", route="users", methods=["GET"]))
+
+    entry = get_openapi_registry()["get::/api/users"]
+    assert entry["summary"] == "Ping."
+    assert entry["description"] == ""
+    assert "_response_inferred" not in entry


### PR DESCRIPTION
## Summary
- Fixes an Oracle-review Medium finding on the just-merged P1-A inference work (#530, #533): at scan time a bare `@app.route` with a docstring but **no documentable return annotation** (e.g. `-> str`, `-> func.HttpResponse`, or unannotated) silently dropped its inferred `summary`/`description`.
- The no-enrichment branch `continue`d on "no inferred response" and the standalone registration branch only fired for an inferred response, so docstring-only metadata never reached the registry. The operation is now materialized when a docstring yields `summary`/`description` too.
- `_response_inferred` is now tagged **only** when a response was actually inferred, so a docstring-only entry carries no phantom supersession flag (keeps precedence logic in `_models_conflict`/`_merge_into_existing` correct).
- Restores the `ruff format` blank line between `_infer_response_from_return` and `_infer_doc_metadata` in `decorator.py` (drift caught by `ruff format --check` but not by the CI `lint` job).

## Tests
- New regressions in `tests/test_docstring_inference.py`: docstring-only bare route with a non-documentable return type, and an unannotated bare route. Both assert `summary`/`description` register and `_response_inferred` is absent.
- `make lint` clean (ruff + mypy strict, 59 files); `ruff format --check` clean.
- Full suite: **857 passed / 6 skipped**, coverage **95.81%** (>= 95% gate).

Closes #534