### PR TITLE
ci(e2e): parameterize Function App Python runtime for 3.13 certification

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -15,6 +15,11 @@ on:
         description: Expected package version (must match source __version__)
         required: false
         type: string
+      python_version:
+        description: Python runtime version for the Azure Function App (e.g. 3.10, 3.13)
+        required: false
+        default: "3.10"
+        type: string
 
 permissions:
   id-token: write
@@ -72,12 +77,13 @@ jobs:
                 location="$AZURE_LOCATION" \
                 functionAppName="${{ steps.names.outputs.app }}" \
                 storageName="${{ steps.names.outputs.st }}" \
+                pythonVersion="${{ inputs.python_version || '3.10' }}" \
                 enableAppInsights=false
 
-      - name: Set up Python 3.10
+      - name: Set up Python ${{ inputs.python_version || '3.10' }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.10"
+          python-version: "${{ inputs.python_version || '3.10' }}"
 
       - name: Install Azure Functions Core Tools
         run: |

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,6 +1,7 @@
 // infra/main.bicep
 // Minimal Azure resources for e2e testing.
-// Creates: Storage Account + Function App (Consumption/Linux/Python 3.10).
+// Creates: Storage Account + Function App (Consumption/Linux/Python, version
+// selectable via the pythonVersion parameter, default 3.10).
 // Optionally creates Application Insights (enableAppInsights=true).
 //
 // Usage:
@@ -21,6 +22,9 @@ param enableAppInsights bool = false
 
 @description('Name of the Application Insights instance (used when enableAppInsights=true).')
 param appInsightsName string = '${functionAppName}-ai'
+
+@description('Python runtime version for the Linux Function App (e.g. 3.10, 3.13).')
+param pythonVersion string = '3.10'
 
 // ── Storage Account ────────────────────────────────────────────────────────
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
@@ -69,7 +73,7 @@ resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
   properties: {
     serverFarmId: hostingPlan.id
     siteConfig: {
-      linuxFxVersion: 'Python|3.10'
+      linuxFxVersion: 'Python|${pythonVersion}'
       appSettings: concat(
         [
           { name: 'AzureWebJobsStorage', value: storageConnectionString }


### PR DESCRIPTION
## Summary
Advances #528 (officially support azure-functions 2.x): makes the real-Azure certification path able to run on a Python 3.13 runtime, which is required to certify the af 2.x line (2.x only installs on 3.13+).

- `infra/main.bicep`: new `pythonVersion` parameter (default `3.10`) driving `linuxFxVersion: 'Python|${pythonVersion}'`. Default preserves current 3.10 behavior.
- `.github/workflows/e2e-azure.yml`: new `python_version` `workflow_dispatch` input (default `3.10`) wired into both the Bicep deploy (`pythonVersion=`) and the `setup-python` step.

## Checklist items advanced (#528)
- [x] Parameterize `infra/main.bicep` `linuxFxVersion` (currently pinned `Python|3.10`).
- [x] Extend `e2e-azure.yml` with a Python 3.13 runtime deploy path.
- Already satisfied earlier (#529): env-marker pin, af 2.x CI matrix, version-aware guard tests, README table, `test_sdk_compat.py` docstring (already reflects public-accessor routing).

## Still required to close #528 (out of scope here — needs cloud)
- Dispatch `e2e-azure.yml` with `python_version=3.13` against the release commit and confirm Consumption (Y1) Python 3.13 availability in the target region — a real-Azure deploy that needs Azure OIDC secrets and incurs cost, so it is a maintainer-run step, not a code change.

## Validation
- `az bicep build` clean locally.
- `e2e-azure.yml` parses as valid YAML.
- No Python/source changes; `make lint` and coverage unaffected.

Refs #528