### PR TITLE
ci(release): scope cookbook dispatch token to the dispatch step

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -315,18 +315,23 @@ jobs:
     name: Trigger cookbook e2e re-verification
     needs: [build, publish]
     runs-on: ubuntu-latest
-    env:
-      # Cross-repo repository_dispatch needs a token with contents:write on the
-      # cookbook repo (GITHUB_TOKEN cannot cross repositories). Supply a PAT or
-      # GitHub App token via the COOKBOOK_DISPATCH_TOKEN secret. When it is unset
-      # the step is skipped, so missing wiring never fails a release.
-      DISPATCH_TOKEN: ${{ secrets.COOKBOOK_DISPATCH_TOKEN }}
     steps:
       - name: Dispatch sibling-release to cookbook
-        if: ${{ env.DISPATCH_TOKEN != '' }}
         env:
           VERSION: ${{ needs.build.outputs.version }}
+          # Cross-repo repository_dispatch needs a token with contents:write on the
+          # cookbook repo (GITHUB_TOKEN cannot cross repositories). Supply a
+          # fine-grained token scoped to azure-functions-cookbook-python
+          # contents:write (or a GitHub App token) via COOKBOOK_DISPATCH_TOKEN.
+          # Scoped to this step so no other step in the job can read it; when the
+          # secret is unset the dispatch is skipped, so missing wiring never fails
+          # a release.
+          DISPATCH_TOKEN: ${{ secrets.COOKBOOK_DISPATCH_TOKEN }}
         run: |
+          if [ -z "${DISPATCH_TOKEN}" ]; then
+            echo "COOKBOOK_DISPATCH_TOKEN not set; skipping cross-repo dispatch."
+            exit 0
+          fi
           curl -sSf -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${DISPATCH_TOKEN}" \


### PR DESCRIPTION
## Context
Partial hardening toward least-privilege for the cross-repo `repository_dispatch` token (umbrella `azure-functions-doctor-python#336`, this repo's #515). Cross-toolkit survey found **no sibling has code to copy** — every sibling uses the same job-level-token pattern this repo had. The only workflow-code improvement demonstrated anywhere in the toolkit is langgraph's step-scoped token env, adopted here.

**Scope note:** #515's real acceptance is a GitHub **secret-admin action** — replacing `COOKBOOK_DISPATCH_TOKEN` with a fine-grained token scoped to `azure-functions-cookbook-python` `contents:write` (or a GitHub App) and rotating the old PAT. That cannot be done in code, so this PR **does not close #515**; it only reduces the token's in-job blast radius.

## Changes
- Move `COOKBOOK_DISPATCH_TOKEN` from job-level `env` to the dispatch step's `env`, so no other step in `notify-cookbook` can read it.
- Replace the step-level `if: ${{ env.DISPATCH_TOKEN != '' }}` guard with an in-script `[ -z ]` empty check (a step `if` cannot reference its own step `env`), preserving the skip-if-unset behavior.

## Verification
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses clean
- [x] Skip-if-unset behavior preserved (empty token → early `exit 0`)

Refs #515