### PR TITLE
ci(e2e): wait for SCM readiness and retry func publish

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -133,7 +133,36 @@ jobs:
       - name: Publish function app
         working-directory: examples/e2e_app
         run: |
-          func azure functionapp publish "${{ steps.names.outputs.app }}" --python --build remote
+          APP="${{ steps.names.outputs.app }}"
+          SCM_URL="https://${APP}.scm.azurewebsites.net"
+          # A freshly-provisioned Consumption app often returns 503 from its SCM
+          # (Kudu) endpoint for the first minute or two; publishing before it is
+          # ready fails with "503 (Site Unavailable)". Wait for SCM readiness,
+          # then retry the remote-build publish with backoff to absorb transients.
+          echo "Waiting for SCM endpoint to become ready: ${SCM_URL}"
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "${SCM_URL}" || echo 000)
+            if [ "${code}" != "503" ] && [ "${code}" != "000" ]; then
+              echo "SCM endpoint responded with HTTP ${code} (attempt ${i}); proceeding."
+              break
+            fi
+            echo "SCM not ready yet (HTTP ${code}, attempt ${i}/30); sleeping 10s..."
+            sleep 10
+          done
+          published=0
+          for attempt in 1 2 3 4 5; do
+            echo "Publish attempt ${attempt}/5..."
+            if func azure functionapp publish "${APP}" --python --build remote; then
+              published=1
+              break
+            fi
+            echo "Publish attempt ${attempt} failed; backing off before retry..."
+            sleep $((attempt * 20))
+          done
+          if [ "${published}" -ne 1 ]; then
+            echo "::error ::func publish failed after 5 attempts for ${APP}"
+            exit 1
+          fi
 
       - name: Run e2e tests
         run: pytest tests/e2e -v --no-cov --html=e2e-report/report.html --self-contained-html


### PR DESCRIPTION
## Context
The real-Azure certification run for #528 ([run 33934818667](https://github.com/yeongseon/azure-functions-openapi-python/actions/runs/33934818667)) failed — but **not** for a runtime/region reason. Diagnosis of the job:

- ✅ `Deploy infra (Bicep)` — Function App provisioned on **Python 3.13, koreacentral, Consumption Y1**
- ✅ `Build candidate wheel and bundle` — version gate passed (0.24.0)
- ❌ `Publish function app` — `func azure functionapp publish ... --build remote` returned `503 (Site Unavailable)`

A freshly-provisioned Consumption app's SCM (Kudu) endpoint returns 503 for the first minute or two; the publish step raced ahead of it. This is a transient readiness race, confirming there is **no** Python 3.13 / koreacentral availability blocker for #528.

## Changes
`.github/workflows/e2e-azure.yml`, `Publish function app` step:
- Poll `https://<app>.scm.azurewebsites.net` until it stops returning `503`/`000` (up to 30 × 10s).
- Retry `func ... publish --build remote` up to 5 times with linear backoff.
- Fail explicitly if all attempts are exhausted.

## Verification
- [x] `yaml.safe_load` parses clean
- [ ] Re-dispatch `e2e-azure.yml` (py 3.13) after merge to confirm a green cert — tracked in #528

Refs #528