### PR TITLE
ci(e2e): migrate infra to Flex Consumption for Python 3.13 certification

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -135,10 +135,11 @@ jobs:
         run: |
           APP="${{ steps.names.outputs.app }}"
           SCM_URL="https://${APP}.scm.azurewebsites.net"
-          # A freshly-provisioned Consumption app often returns 503 from its SCM
-          # (Kudu) endpoint for the first minute or two; publishing before it is
-          # ready fails with "503 (Site Unavailable)". Wait for SCM readiness,
-          # then retry the remote-build publish with backoff to absorb transients.
+          # A freshly-provisioned Flex Consumption app can briefly return 503 from
+          # its SCM (Kudu) endpoint for the first minute or two; publishing before
+          # it is ready fails with "503 (Site Unavailable)". Wait for SCM readiness,
+          # then retry the publish with backoff to absorb transients. Flex Consumption
+          # performs the remote build automatically, so no --build flag is passed.
           echo "Waiting for SCM endpoint to become ready: ${SCM_URL}"
           for i in $(seq 1 30); do
             code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "${SCM_URL}" || echo 000)
@@ -152,7 +153,7 @@ jobs:
           published=0
           for attempt in 1 2 3 4 5; do
             echo "Publish attempt ${attempt}/5..."
-            if func azure functionapp publish "${APP}" --python --build remote; then
+            if func azure functionapp publish "${APP}" --python; then
               published=1
               break
             fi

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,14 +1,19 @@
 // infra/main.bicep
 // Minimal Azure resources for e2e testing.
-// Creates: Storage Account + Function App (Consumption/Linux/Python, version
-// selectable via the pythonVersion parameter, default 3.10).
+// Creates: Storage Account + Function App on a Flex Consumption (FC1) plan,
+// Linux/Python, version selectable via the pythonVersion parameter (default 3.10).
 // Optionally creates Application Insights (enableAppInsights=true).
+//
+// Flex Consumption (not the classic Y1 Consumption plan) is required because
+// Python 3.13+ is only available on Flex Consumption / Premium / Dedicated —
+// the classic Linux Consumption plan tops out at Python 3.12.
+// See https://learn.microsoft.com/azure/azure-functions/functions-versions?pivots=programming-language-python
 //
 // Usage:
 //   az deployment group create -g <rg> -f infra/main.bicep \
-//     -p functionAppName=<name> storageName=<name> location=<loc>
+//     -p functionAppName=<name> storageName=<name> location=<loc> pythonVersion=3.13
 
-@description('Azure region for all resources.')
+@description('Azure region for all resources (must support Flex Consumption).')
 param location string = resourceGroup().location
 
 @description('Name of the Function App (must be globally unique).')
@@ -23,8 +28,17 @@ param enableAppInsights bool = false
 @description('Name of the Application Insights instance (used when enableAppInsights=true).')
 param appInsightsName string = '${functionAppName}-ai'
 
-@description('Python runtime version for the Linux Function App (e.g. 3.10, 3.13).')
+@description('Python runtime version for the Flex Consumption Function App (e.g. 3.10, 3.13).')
 param pythonVersion string = '3.10'
+
+@description('Per-instance memory (MB) for the Flex Consumption app.')
+param instanceMemoryMB int = 2048
+
+@description('Maximum number of instances the app can scale out to (Flex minimum is 40).')
+param maximumInstanceCount int = 40
+
+// Name of the blob container that holds the deployment (.zip) package.
+var deploymentContainerName = 'app-package'
 
 // ── Storage Account ────────────────────────────────────────────────────────
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
@@ -36,6 +50,17 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
     minimumTlsVersion: 'TLS1_2'
     allowBlobPublicAccess: false
   }
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+// Deployment package container required by the Flex Consumption plan.
+resource deploymentContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  parent: blobService
+  name: deploymentContainerName
 }
 
 var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
@@ -51,35 +76,54 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = if (enableAppI
   }
 }
 
-// ── Consumption Hosting Plan ───────────────────────────────────────────────
-resource hostingPlan 'Microsoft.Web/serverfarms@2023-01-01' = {
+// ── Flex Consumption Hosting Plan ──────────────────────────────────────────
+resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   name: '${functionAppName}-plan'
   location: location
   sku: {
-    name: 'Y1'
-    tier: 'Dynamic'
+    name: 'FC1'
+    tier: 'FlexConsumption'
   }
-  kind: 'linux'
+  kind: 'functionapp'
   properties: {
     reserved: true
   }
 }
 
-// ── Function App ───────────────────────────────────────────────────────────
-resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
+// ── Function App (Flex Consumption) ────────────────────────────────────────
+resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
   name: functionAppName
   location: location
   kind: 'functionapp,linux'
+  dependsOn: [ deploymentContainer ]
   properties: {
     serverFarmId: hostingPlan.id
+    httpsOnly: true
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          type: 'blobContainer'
+          value: '${storageAccount.properties.primaryEndpoints.blob}${deploymentContainerName}'
+          authentication: {
+            type: 'StorageAccountConnectionString'
+            storageAccountConnectionStringName: 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
+          }
+        }
+      }
+      scaleAndConcurrency: {
+        instanceMemoryMB: instanceMemoryMB
+        maximumInstanceCount: maximumInstanceCount
+      }
+      runtime: {
+        name: 'python'
+        version: pythonVersion
+      }
+    }
     siteConfig: {
-      linuxFxVersion: 'Python|${pythonVersion}'
       appSettings: concat(
         [
           { name: 'AzureWebJobsStorage', value: storageConnectionString }
-          { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
-          { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'python' }
-          { name: 'SCM_DO_BUILD_DURING_DEPLOYMENT', value: 'true' }
+          { name: 'DEPLOYMENT_STORAGE_CONNECTION_STRING', value: storageConnectionString }
         ],
         enableAppInsights
           ? [
@@ -91,7 +135,6 @@ resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
           : []
       )
     }
-    httpsOnly: true
   }
 }
 


### PR DESCRIPTION
## Context
The real-Azure Python 3.13 certification for #528 has been failing at the publish step: the app deploys, the wheel builds, but the SCM/Kudu endpoint returns a persistent `503 (Site Unavailable)` and never becomes healthy. Root cause (confirmed against [Microsoft Learn](https://learn.microsoft.com/azure/azure-functions/functions-versions?pivots=programming-language-python)): **the classic Linux Consumption (Y1) plan tops out at Python 3.12** — "newer Python versions aren't added to Linux Consumption." Python 3.13/3.14 require **Flex Consumption** (or Premium/Dedicated).

`az functionapp list-flexconsumption-runtimes --location koreacentral --runtime python` confirms koreacentral Flex supports Python 3.10–3.14.

## Changes
- **`infra/main.bicep`** migrated from Y1 Consumption → **Flex Consumption (FC1)**:
  - `serverfarms` → `FC1` / `FlexConsumption` (`reserved: true`)
  - `sites` → `functionAppConfig` with `runtime` (`python`/`pythonVersion`), `scaleAndConcurrency` (2048 MB / max 40), and `deployment.storage` via a `blobContainer` using `StorageAccountConnectionString` auth
  - new `app-package` deployment container + explicit `dependsOn` from the site (so the site is never created before its deployment container exists)
  - dropped classic-only settings: `linuxFxVersion`, `FUNCTIONS_EXTENSION_VERSION`, `FUNCTIONS_WORKER_RUNTIME`, `SCM_DO_BUILD_DURING_DEPLOYMENT`
- **`.github/workflows/e2e-azure.yml`**: publish step drops `--build remote` (Flex performs the remote build automatically; the flag is Consumption/Premium-only). SCM-readiness wait + retry loop retained.

## Validation
- `az bicep build infra/main.bicep` compiles clean (only pre-existing guarded-appInsights BCP318 warnings).
- Reviewed by Oracle: go, with the container `dependsOn` as the one required fix (applied).
- Real-Azure certification on this branch is the remaining gate before merge.

## Out of scope
- Lifting the `azure-functions<2` pin — already done in `pyproject.toml`; #528 only needs the green real-Azure cert.

Refs #528