### PR TITLE
docs(readme): sync translated READMEs with interpreter-aware pin and Flex/3.13 certification

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -142,9 +142,10 @@ azure-functions-openapi
 | ----------------- | :---------: | :---------: | :---------: | :---------: | :---------: |
 | `1.21.0`（下限）  | ✅ 検証済 |             |             |             |             |
 | `1.24.0`          | ✅ 検証済 |             |             |             |             |
-| `latest` (`<2.0`) | ✅ 検証済 | ✅ 検証済 | ✅ 検証済 | ✅ 検証済 | ✅ 検証済 |
+| `latest 1.x`      | ✅ 検証済 | ✅ 検証済 | ✅ 検証済 |             |             |
+| `2.x` (`>=2,<3`)  |           |           |           | ✅ 検証済 | ✅ 検証済 |
 
-`pyproject.toml` のバージョンピンは `azure-functions>=1.21.0,<2.0.0` です。下限が `1.21.0` なのは、それ以前のリリースが `FunctionBuilder.__call__` から `None` を返すためです（テストと CLI 抽出でデコレートされたハンドラーの直接呼び出しが壊れる）。より新しい SDK が必要な場合はイシューを開いてください。上限を設けているのは、`azure-functions` 2.x が Python < 3.13 のサポートを廃止し、まだ `@openapi` で検証されていないためです。
+`pyproject.toml` のバージョンピンはインタプリタに依存します: Python < 3.13 では `azure-functions>=1.21.0,<2.0.0`、Python 3.13+ では `azure-functions>=1.21.0`（上限なし）です。下限が `1.21.0` なのは、それ以前のリリースが `FunctionBuilder.__call__` から `None` を返すためです（テストと CLI 抽出でデコレートされたハンドラーの直接呼び出しが壊れる）。分割している理由は、`azure-functions` 2.x が Python < 3.13 のサポートを廃止するため、2.x ラインは Python 3.13+ でのみインストール・提供されるからです。2.x パスは CI の専用 wheel ベース互換性マトリックス（実際の Python 3.13 および 3.14 インタプリタ）と、実際の Azure 認証 — koreacentral の Flex Consumption プランにデプロイされた Python 3.13 Function App — によって実証されています。上限解除の作業は [イシュー #528](https://github.com/yeongseon/azure-functions-openapi-python/issues/528) と [イシュー #488](https://github.com/yeongseon/azure-functions-openapi-python/issues/488) を参照してください。
 
 ## Quick Start
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -142,9 +142,10 @@ azure-functions-openapi
 | ----------------- | :---------: | :---------: | :---------: | :---------: | :---------: |
 | `1.21.0` (최소)   | ✅ 테스트됨 |             |             |             |             |
 | `1.24.0`          | ✅ 테스트됨 |             |             |             |             |
-| `latest` (`<2.0`) | ✅ 테스트됨 | ✅ 테스트됨 | ✅ 테스트됨 | ✅ 테스트됨 | ✅ 테스트됨 |
+| `latest 1.x`      | ✅ 테스트됨 | ✅ 테스트됨 | ✅ 테스트됨 |             |             |
+| `2.x` (`>=2,<3`)  |             |             |             | ✅ 테스트됨 | ✅ 테스트됨 |
 
-`pyproject.toml`의 버전 핀은 `azure-functions>=1.21.0,<2.0.0`입니다. 최소 버전이 `1.21.0`인 이유는 그 이전 릴리스가 `FunctionBuilder.__call__`에서 `None`을 반환하기 때문입니다(테스트와 CLI 추출에서 데코레이트된 핸들러의 직접 호출이 깨짐). 더 새로운 SDK가 필요하면 이슈를 열어 주세요. 상한을 둔 이유는 `azure-functions` 2.x가 Python < 3.13 지원을 중단하며 아직 `@openapi`로 검증되지 않았기 때문입니다.
+`pyproject.toml`의 버전 핀은 인터프리터에 따라 다릅니다: Python < 3.13에서는 `azure-functions>=1.21.0,<2.0.0`, Python 3.13+에서는 `azure-functions>=1.21.0`(상한 없음)입니다. 최소 버전이 `1.21.0`인 이유는 그 이전 릴리스가 `FunctionBuilder.__call__`에서 `None`을 반환하기 때문입니다(테스트와 CLI 추출에서 데코레이트된 핸들러의 직접 호출이 깨짐). 이렇게 나눈 이유는 `azure-functions` 2.x가 Python < 3.13 지원을 중단하므로, 2.x 라인은 Python 3.13+에서만 설치 가능하고 제공되기 때문입니다. 2.x 경로는 CI의 전용 wheel 기반 호환성 매트릭스(실제 Python 3.13 및 3.14 인터프리터)와 실제 Azure 인증 — koreacentral의 Flex Consumption 요금제에 배포된 Python 3.13 Function App — 으로 검증되었습니다. 상한 해제 작업은 [이슈 #528](https://github.com/yeongseon/azure-functions-openapi-python/issues/528)과 [이슈 #488](https://github.com/yeongseon/azure-functions-openapi-python/issues/488)을 참고하세요.
 
 ## Quick Start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -142,9 +142,10 @@ azure-functions-openapi
 | ----------------- | :---------: | :---------: | :---------: | :---------: | :---------: |
 | `1.21.0`（下限）  | ✅ 已测试 |             |             |             |             |
 | `1.24.0`          | ✅ 已测试 |             |             |             |             |
-| `latest` (`<2.0`) | ✅ 已测试 | ✅ 已测试 | ✅ 已测试 | ✅ 已测试 | ✅ 已测试 |
+| `latest 1.x`      | ✅ 已测试 | ✅ 已测试 | ✅ 已测试 |           |           |
+| `2.x` (`>=2,<3`)  |           |           |           | ✅ 已测试 | ✅ 已测试 |
 
-`pyproject.toml` 中的版本锁定为 `azure-functions>=1.21.0,<2.0.0`。下限为 `1.21.0` 是因为更早的版本会从 `FunctionBuilder.__call__` 返回 `None`（会破坏测试和 CLI 提取中对装饰处理器的直接调用）。如果你需要更新的 SDK，请提交问题；设置上限是有意为之，因为 `azure-functions` 2.x 放弃了对 Python < 3.13 的支持，且尚未针对 `@openapi` 进行验证。
+`pyproject.toml` 中的版本锁定与解释器相关：在 Python < 3.13 上为 `azure-functions>=1.21.0,<2.0.0`，在 Python 3.13+ 上为 `azure-functions>=1.21.0`（无上限）。下限为 `1.21.0` 是因为更早的版本会从 `FunctionBuilder.__call__` 返回 `None`（会破坏测试和 CLI 提取中对装饰处理器的直接调用）。之所以拆分，是因为 `azure-functions` 2.x 放弃了对 Python < 3.13 的支持，因此 2.x 系列仅在 Python 3.13+ 上可安装和提供。2.x 路径已通过 CI 中专用的基于 wheel 的兼容性矩阵（真实的 Python 3.13 和 3.14 解释器）以及真实 Azure 认证 —— 部署在 koreacentral Flex Consumption 计划上的 Python 3.13 Function App —— 得到验证。解除上限的相关工作请参阅 [问题 #528](https://github.com/yeongseon/azure-functions-openapi-python/issues/528) 和 [问题 #488](https://github.com/yeongseon/azure-functions-openapi-python/issues/488)。
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Sync `README.ko.md`, `README.ja.md`, and `README.zh-CN.md` with the canonical English `README.md` SDK Compatibility section.
- Split the compatibility table's old `latest (<2.0)` row into `latest 1.x` and `2.x` (`>=2,<3`) rows, matching the English matrix.
- Rewrite the version-pin paragraph to describe the interpreter-aware pin (`<2.0.0` on Python < 3.13, uncapped on 3.13+) and the completed real-Azure certification of the 2.x path on a Flex Consumption plan (Python 3.13, koreacentral), with #528/#488 references.
- Staleness banners preserved in all three files.

## Notes
- Translations are best-effort per AGENTS.md; English remains canonical. No English `README.md` changes here (already done in #545).

Closes #546