### PR TITLE
chore: ignore local Bicep build artifacts (infra/*.json)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ site/
 # Agent orchestration state
 .sisyphus/
 .omc/
+
+
+# Compiled Bicep/ARM output (only infra/*.bicep is tracked)
+infra/*.json


### PR DESCRIPTION
## Summary
- Ignore `infra/*.json` (compiled Bicep/ARM output from `az bicep build`) so the generated artifact can never be staged accidentally.
- `infra/main.bicep` remains tracked and unaffected.

Closes #548