### PR TITLE
fix(deps): re-add <3.0.0 upper cap on azure-functions for Python 3.13+

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -145,7 +145,7 @@ azure-functions-openapi
 | `latest 1.x`      | ✅ 検証済 | ✅ 検証済 | ✅ 検証済 |             |             |
 | `2.x` (`>=2,<3`)  |           |           |           | ✅ 検証済 | ✅ 検証済 |
 
-`pyproject.toml` のバージョンピンはインタプリタに依存します: Python < 3.13 では `azure-functions>=1.21.0,<2.0.0`、Python 3.13+ では `azure-functions>=1.21.0`（上限なし）です。下限が `1.21.0` なのは、それ以前のリリースが `FunctionBuilder.__call__` から `None` を返すためです（テストと CLI 抽出でデコレートされたハンドラーの直接呼び出しが壊れる）。分割している理由は、`azure-functions` 2.x が Python < 3.13 のサポートを廃止するため、2.x ラインは Python 3.13+ でのみインストール・提供されるからです。2.x パスは CI の専用 wheel ベース互換性マトリックス（実際の Python 3.13 および 3.14 インタプリタ）と、実際の Azure 認証 — koreacentral の Flex Consumption プランにデプロイされた Python 3.13 Function App — によって実証されています。上限解除の作業は [イシュー #528](https://github.com/yeongseon/azure-functions-openapi-python/issues/528) と [イシュー #488](https://github.com/yeongseon/azure-functions-openapi-python/issues/488) を参照してください。
+`pyproject.toml` のバージョンピンはインタプリタに依存します: Python < 3.13 では `azure-functions>=1.21.0,<2.0.0`、Python 3.13+ では `azure-functions>=1.21.0,<3.0.0`（未認証の `azure-functions` 3.x を除外）です。下限が `1.21.0` なのは、それ以前のリリースが `FunctionBuilder.__call__` から `None` を返すためです（テストと CLI 抽出でデコレートされたハンドラーの直接呼び出しが壊れる）。分割している理由は、`azure-functions` 2.x が Python < 3.13 のサポートを廃止するため、2.x ラインは Python 3.13+ でのみインストール・提供されるからです。2.x パスは CI の専用 wheel ベース互換性マトリックス（実際の Python 3.13 および 3.14 インタプリタ）と、実際の Azure 認証 — koreacentral の Flex Consumption プランにデプロイされた Python 3.13 Function App — によって実証されています。上限解除の作業は [イシュー #528](https://github.com/yeongseon/azure-functions-openapi-python/issues/528) と [イシュー #488](https://github.com/yeongseon/azure-functions-openapi-python/issues/488) を参照してください。
 
 ## Quick Start
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -145,7 +145,7 @@ azure-functions-openapi
 | `latest 1.x`      | ✅ 테스트됨 | ✅ 테스트됨 | ✅ 테스트됨 |             |             |
 | `2.x` (`>=2,<3`)  |             |             |             | ✅ 테스트됨 | ✅ 테스트됨 |
 
-`pyproject.toml`의 버전 핀은 인터프리터에 따라 다릅니다: Python < 3.13에서는 `azure-functions>=1.21.0,<2.0.0`, Python 3.13+에서는 `azure-functions>=1.21.0`(상한 없음)입니다. 최소 버전이 `1.21.0`인 이유는 그 이전 릴리스가 `FunctionBuilder.__call__`에서 `None`을 반환하기 때문입니다(테스트와 CLI 추출에서 데코레이트된 핸들러의 직접 호출이 깨짐). 이렇게 나눈 이유는 `azure-functions` 2.x가 Python < 3.13 지원을 중단하므로, 2.x 라인은 Python 3.13+에서만 설치 가능하고 제공되기 때문입니다. 2.x 경로는 CI의 전용 wheel 기반 호환성 매트릭스(실제 Python 3.13 및 3.14 인터프리터)와 실제 Azure 인증 — koreacentral의 Flex Consumption 요금제에 배포된 Python 3.13 Function App — 으로 검증되었습니다. 상한 해제 작업은 [이슈 #528](https://github.com/yeongseon/azure-functions-openapi-python/issues/528)과 [이슈 #488](https://github.com/yeongseon/azure-functions-openapi-python/issues/488)을 참고하세요.
+`pyproject.toml`의 버전 핀은 인터프리터에 따라 다릅니다: Python < 3.13에서는 `azure-functions>=1.21.0,<2.0.0`, Python 3.13+에서는 `azure-functions>=1.21.0,<3.0.0`(미인증 `azure-functions` 3.x 차단)입니다. 최소 버전이 `1.21.0`인 이유는 그 이전 릴리스가 `FunctionBuilder.__call__`에서 `None`을 반환하기 때문입니다(테스트와 CLI 추출에서 데코레이트된 핸들러의 직접 호출이 깨짐). 이렇게 나눈 이유는 `azure-functions` 2.x가 Python < 3.13 지원을 중단하므로, 2.x 라인은 Python 3.13+에서만 설치 가능하고 제공되기 때문입니다. 2.x 경로는 CI의 전용 wheel 기반 호환성 매트릭스(실제 Python 3.13 및 3.14 인터프리터)와 실제 Azure 인증 — koreacentral의 Flex Consumption 요금제에 배포된 Python 3.13 Function App — 으로 검증되었습니다. 상한 해제 작업은 [이슈 #528](https://github.com/yeongseon/azure-functions-openapi-python/issues/528)과 [이슈 #488](https://github.com/yeongseon/azure-functions-openapi-python/issues/488)을 참고하세요.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -185,9 +185,10 @@ This package discovers routes, methods, and handlers from the `azure-functions` 
 | `2.x` (`>=2,<3`)   |             |             |             | ✅ tested   | ✅ tested   |
 
 The version pin in `pyproject.toml` is interpreter-aware:
-`azure-functions>=1.21.0,<2.0.0` on Python < 3.13, and `azure-functions>=1.21.0`
-(no upper cap) on Python 3.13+. The floor is `1.21.0` because earlier releases
-return `None` from `FunctionBuilder.__call__` (breaking direct invocation of
+`azure-functions>=1.21.0,<2.0.0` on Python < 3.13, and `azure-functions>=1.21.0,<3.0.0`
+on Python 3.13+. The `<3.0.0` ceiling keeps an uncertified `azure-functions` 3.x
+out. The floor is `1.21.0` because earlier releases return `None` from
+`FunctionBuilder.__call__` (breaking direct invocation of
 decorated handlers in tests and CLI extraction). The split exists because
 `azure-functions` 2.x drops support for Python < 3.13, so the 2.x line is only
 installable — and only offered — on Python 3.13+. The 2.x path is proven by a

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -145,7 +145,7 @@ azure-functions-openapi
 | `latest 1.x`      | ✅ 已测试 | ✅ 已测试 | ✅ 已测试 |           |           |
 | `2.x` (`>=2,<3`)  |           |           |           | ✅ 已测试 | ✅ 已测试 |
 
-`pyproject.toml` 中的版本锁定与解释器相关：在 Python < 3.13 上为 `azure-functions>=1.21.0,<2.0.0`，在 Python 3.13+ 上为 `azure-functions>=1.21.0`（无上限）。下限为 `1.21.0` 是因为更早的版本会从 `FunctionBuilder.__call__` 返回 `None`（会破坏测试和 CLI 提取中对装饰处理器的直接调用）。之所以拆分，是因为 `azure-functions` 2.x 放弃了对 Python < 3.13 的支持，因此 2.x 系列仅在 Python 3.13+ 上可安装和提供。2.x 路径已通过 CI 中专用的基于 wheel 的兼容性矩阵（真实的 Python 3.13 和 3.14 解释器）以及真实 Azure 认证 —— 部署在 koreacentral Flex Consumption 计划上的 Python 3.13 Function App —— 得到验证。解除上限的相关工作请参阅 [问题 #528](https://github.com/yeongseon/azure-functions-openapi-python/issues/528) 和 [问题 #488](https://github.com/yeongseon/azure-functions-openapi-python/issues/488)。
+`pyproject.toml` 中的版本锁定与解释器相关：在 Python < 3.13 上为 `azure-functions>=1.21.0,<2.0.0`，在 Python 3.13+ 上为 `azure-functions>=1.21.0,<3.0.0`（挡住未认证的 `azure-functions` 3.x）。下限为 `1.21.0` 是因为更早的版本会从 `FunctionBuilder.__call__` 返回 `None`（会破坏测试和 CLI 提取中对装饰处理器的直接调用）。之所以拆分，是因为 `azure-functions` 2.x 放弃了对 Python < 3.13 的支持，因此 2.x 系列仅在 Python 3.13+ 上可安装和提供。2.x 路径已通过 CI 中专用的基于 wheel 的兼容性矩阵（真实的 Python 3.13 和 3.14 解释器）以及真实 Azure 认证 —— 部署在 koreacentral Flex Consumption 计划上的 Python 3.13 Function App —— 得到验证。解除上限的相关工作请参阅 [问题 #528](https://github.com/yeongseon/azure-functions-openapi-python/issues/528) 和 [问题 #488](https://github.com/yeongseon/azure-functions-openapi-python/issues/488)。
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,13 @@ classifiers = [
 dependencies = [
     # azure-functions 2.x drops Python < 3.13, so the constraint is split by
     # interpreter: Python < 3.13 stays capped at <2.0.0 (2.x is uninstallable
-    # there), while Python >= 3.13 is allowed onto the 2.x line. The 2.x path is
-    # proven by the wheel-based "azure-functions 2.x compat" matrix in
-    # ci-test.yml (real Python 3.13/3.14 interpreters). Real-Azure certification
-    # of the 2.x path (via e2e-azure.yml) is a required follow-up, tracked by
-    # issue #528 (cap-lift); see also #488 (compat lane).
+    # there), while Python >= 3.13 is allowed onto the 2.x line but still capped
+    # below <3.0.0 so an uncertified azure-functions 3.x is never pulled in
+    # silently. The 2.x path is proven by the wheel-based "azure-functions 2.x
+    # compat" matrix in ci-test.yml (real Python 3.13/3.14 interpreters) and
+    # certified against real Azure via e2e-azure.yml; see #528 and #488.
     "azure-functions>=1.21.0,<2.0.0; python_version < '3.13'",
-    "azure-functions>=1.21.0; python_version >= '3.13'",
+    "azure-functions>=1.21.0,<3.0.0; python_version >= '3.13'",
     "pydantic>=2.0,<3.0",
     "PyYAML",
 ]

--- a/tests/test_sdk_compat.py
+++ b/tests/test_sdk_compat.py
@@ -34,8 +34,10 @@ def test_installed_azure_functions_version_meets_pin() -> None:
 
     Below Python 3.13 the pin caps ``azure-functions`` at ``<2.0.0`` (the 2.x
     line drops those interpreters). On Python 3.13+ the ``<2.0.0`` cap is lifted
-    (issue #528), so only the ``>=1.21.0`` floor is enforced. This catches
-    accidental downgrades and confirms the CI matrix installed what it intended.
+    (issue #528) but an interpreter-aware ``<3.0.0`` ceiling still applies (an
+    uncertified future 3.x major must not silently install). This catches
+    accidental downgrades and cap removals, and confirms the CI matrix
+    installed what it intended.
     """
     installed = _metadata.version("azure-functions")
     major_minor = tuple(int(p) for p in installed.split(".")[:2])
@@ -49,6 +51,13 @@ def test_installed_azure_functions_version_meets_pin() -> None:
             f"{sys.version_info.major}.{sys.version_info.minor}, but the pin caps "
             "it at <2.0.0 below Python 3.13. See issue #528 before widening the "
             "ceiling on older interpreters."
+        )
+    else:
+        assert major_minor < (3, 0), (
+            f"azure-functions {installed} reached the 3.x line on Python "
+            f"{sys.version_info.major}.{sys.version_info.minor}, but the pin caps "
+            "it at <3.0.0 on Python 3.13+ until a future 3.x major is certified. "
+            "See issue #550 before widening the ceiling."
         )
 
 

--- a/tests/test_sdk_compat_adapter.py
+++ b/tests/test_sdk_compat_adapter.py
@@ -66,7 +66,8 @@ def test_installed_sdk_is_within_supported_matrix() -> None:
 
     Below Python 3.13 the pin is ``>=1.21.0,<2.0.0``. On Python 3.13+ the
     ``<2.0.0`` ceiling is lifted (issue #528) and the wheel-based 2.x compat
-    matrix proves the adapter holds, so only the ``>=1.21.0`` floor is enforced.
+    matrix proves the adapter holds, but an interpreter-aware ``<3.0.0`` ceiling
+    still applies so an uncertified future 3.x major cannot silently install.
     """
     installed = _metadata.version("azure-functions")
     major_minor = tuple(int(p) for p in installed.split(".")[:2])
@@ -80,6 +81,13 @@ def test_installed_sdk_is_within_supported_matrix() -> None:
             f"azure-functions {installed} is above the <2.0.0 ceiling on Python "
             f"{sys.version_info.major}.{sys.version_info.minor}. The ceiling is "
             "only lifted on Python 3.13+ (issue #528)."
+        )
+    else:
+        assert major_minor < (3, 0), (
+            f"azure-functions {installed} reached the 3.x line on Python "
+            f"{sys.version_info.major}.{sys.version_info.minor}, but the pin caps "
+            "it at <3.0.0 on Python 3.13+ until a future 3.x major is certified. "
+            "See issue #550."
         )
 
 


### PR DESCRIPTION
## Summary
- Re-add the `<3.0.0` upper cap to the `azure-functions` pin for Python 3.13+, which previously had no upper bound (`azure-functions>=1.21.0`). Without the cap, an uncertified `azure-functions` 3.x could be pulled in silently.
- Update the interpreter-aware pin comment in `pyproject.toml` to explain the 3.x ceiling.
- Sync the pin documentation across `README.md` and the translated READMEs (`ko`, `ja`, `zh-CN`).

## Rationale
The 2.x path is the certified line (wheel-based compat matrix + real-Azure certification via `e2e-azure.yml`). A 3.x release has no certification, so it must not install silently.

Closes #550