### PR TITLE
fix(decorator): make docstring inference opt-in before it ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Spec matches code. Always. Swagger UI out of the box.
 - **Swagger UI** — built-in `/docs` endpoint with security defaults
 - **CLI tooling** — generate specs at build time for CI validation
 - **Schema support** — query, path, header, body, and response schemas
-- **Metadata inference** — infer the `200` response from a handler's return type and `summary`/`description` from its docstring, gap-fill-only and explicit-always-wins (see [Usage Guide](docs/usage.md#inferred-metadata-return-type--docstring))
+- **Metadata inference** — infer the `200` response from a handler's return type (always on), and opt into `summary`/`description` inference from its docstring with `infer_docstring=True`; both are gap-fill-only and explicit-always-wins (see [Usage Guide](docs/usage.md#inferred-metadata-return-type--docstring))
 - **`auth_level` security inference** — opt-in `infer_auth_level=True` derives OpenAPI security from a route's Azure Functions `auth_level` (see [Usage Guide](docs/usage.md#infer-security-from-auth_level-opt-in))
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -244,7 +244,9 @@ decorator-time (`@openapi`) and scan-time (a bare `@app.route` with no
 ### Return-type inference
 
 When you supply no explicit `responses=`, the handler's return annotation infers
-the `200` response:
+the `200` response. This inference is always on — a return **type** is a
+structural declaration, not free-form prose, so publishing it needs no separate
+consent:
 
 ```python
 @openapi(summary="Get order")
@@ -263,14 +265,20 @@ def get_order(req: func.HttpRequest) -> OrderResponse:  # -> 200 OrderResponse s
   `from __future__ import annotations`) simply infers nothing rather than
   failing.
 
-### Docstring inference
+### Docstring inference (opt-in)
 
-When you omit `summary`/`description`, the handler docstring fills them: the
-first non-empty line becomes the `summary`, and the remainder becomes the
-`description`.
+Docstring inference is **opt-in** and **off by default**. A handler's docstring
+is prose written for developers, not necessarily public API documentation, so it
+is never published without your explicit consent. Enable it per handler with
+`infer_docstring=True` (decorator) or per scan with
+`scan_endpoint_metadata(..., infer_docstring=True)`.
+
+When enabled and you omit `summary`/`description`, the handler docstring fills
+them: the first non-empty line becomes the `summary`, and the remainder becomes
+the `description`.
 
 ```python
-@openapi()
+@openapi(infer_docstring=True)
 @app.route(route="ping", methods=["GET"])
 def ping(req: func.HttpRequest) -> str:
     """Health check.
@@ -282,7 +290,11 @@ def ping(req: func.HttpRequest) -> str:
 # description="Returns 200 while the app is serving traffic."
 ```
 
-Each field is inferred **independently**, and explicit always wins:
+With the default `infer_docstring=False`, the same handler registers an empty
+`summary`/`description` and the docstring is ignored.
+
+When enabled, each field is inferred **independently**, and explicit always
+wins:
 
 - Omit `summary`/`description` (leave them unset) → inferred from the docstring.
 - Pass an explicit non-empty value → that value is used, docstring ignored for

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -836,13 +836,14 @@ def scan_validation_metadata(
     registry: OpenAPIRegistry | None = None,
     infer_docstring: bool = False,
 ) -> None:
-    """Deprecated alias for :func:`scan_endpoint_metadata`.
+    """Deprecated alias for :func:`scan_endpoint_metadata` (forwards ``infer_docstring``).
 
     The scanner now primarily consumes the namespace-neutral ``"endpoint"``
     contract (the ``"validation"`` namespace is only a fallback), so the
     ``scan_validation_metadata`` name is a misnomer. Use
     :func:`scan_endpoint_metadata` instead. This alias forwards unchanged and
-    will be removed in a future minor release.
+    will be removed in a future minor release. The opt-in ``infer_docstring``
+    flag is forwarded unchanged to :func:`scan_endpoint_metadata`.
     """
     warnings.warn(
         "scan_validation_metadata() is deprecated; use scan_endpoint_metadata() "

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -456,6 +456,7 @@ def scan_endpoint_metadata(
     app: Any,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
     registry: OpenAPIRegistry | None = None,
+    infer_docstring: bool = False,
 ) -> None:
     """Scan function builders for toolkit metadata and register OpenAPI operations.
 
@@ -477,6 +478,11 @@ def scan_endpoint_metadata(
     selected app's operations rather than every ``@openapi`` imported from the
     module. Programmatic ``register_openapi_metadata`` entries (which are not
     tied to any app object) are never seeded into an isolated registry.
+
+    ``infer_docstring`` (opt-in, #551): when ``True``, gap-fill
+    ``summary``/``description`` from a bare handler's docstring. Off by default
+    so a handler's prose docstring is never published without explicit consent.
+    Return-type response inference is independent and always on.
     """
     reg = registry if registry is not None else _global_registry
     isolated = reg is not _global_registry
@@ -612,7 +618,8 @@ def scan_endpoint_metadata(
         inferred_description = ""
         if canonical_target is None and endpoint_hints is None and not endpoint_skew:
             inferred_response_model, inferred_response = _infer_response_from_return(handler)
-            inferred_summary, inferred_description = _infer_doc_metadata(handler)
+            if infer_docstring:
+                inferred_summary, inferred_description = _infer_doc_metadata(handler)
 
         for method in methods:
             endpoint_key = f"{method}::{path}"
@@ -827,6 +834,7 @@ def scan_validation_metadata(
     app: Any,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
     registry: OpenAPIRegistry | None = None,
+    infer_docstring: bool = False,
 ) -> None:
     """Deprecated alias for :func:`scan_endpoint_metadata`.
 
@@ -842,4 +850,6 @@ def scan_validation_metadata(
         DeprecationWarning,
         stacklevel=2,
     )
-    scan_endpoint_metadata(app, route_prefix, registry=registry)
+    scan_endpoint_metadata(
+        app, route_prefix, registry=registry, infer_docstring=infer_docstring
+    )

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -363,6 +363,8 @@ def openapi(
     # ── querystring (OpenAPI 3.2 only) ───────────────────────
     querystring: type[BaseModel] | dict[str, Any] | None = None,
     querystring_media_type: str = "application/x-www-form-urlencoded",
+    # ── inference toggles ─────────────────────────────────────────
+    infer_docstring: bool = False,
 ) -> Callable[[F], F]:
     """
     Decorator that attaches OpenAPI metadata to an Azure Functions handler.
@@ -421,13 +423,15 @@ def openapi(
     Parameters
     ----------
     summary:
-        Short description shown in Swagger UI. Defaults to ``None`` (unset),
-        in which case it is inferred from the handler docstring's first line;
-        pass ``""`` to explicitly suppress that inference.
+        Short description shown in Swagger UI. Defaults to ``None`` (unset).
+        When ``infer_docstring=True`` and this is left unset, it is inferred
+        from the handler docstring's first line; pass ``""`` to explicitly
+        suppress that inference.
     description:
-        Longer Markdown-enabled description. Defaults to ``None`` (unset), in
-        which case it is inferred from the handler docstring body; pass ``""``
-        to explicitly suppress that inference.
+        Longer Markdown-enabled description. Defaults to ``None`` (unset).
+        When ``infer_docstring=True`` and this is left unset, it is inferred
+        from the handler docstring body; pass ``""`` to explicitly suppress
+        that inference.
     tags:
         List of group tags.
     operation_id:
@@ -481,6 +485,12 @@ def openapi(
     querystring_media_type:
         Media type used to encode the querystring content. Defaults to
         ``application/x-www-form-urlencoded``.
+    infer_docstring:
+        When ``True`` (opt-in, #551), gap-fill ``summary``/``description``
+        from the handler's docstring for any of those fields left unset
+        (``None``). Defaults to ``False`` so a handler's prose docstring is
+        never published as public API documentation without explicit consent.
+        Return-type response inference is independent and always on.
 
     Returns
     -------
@@ -578,8 +588,11 @@ def openapi(
                     resolved_response = inferred_response
                     response_inferred = True
 
-            # ── docstring inference (P1-A Phase 2) ───────────────────────
-            # Lowest-precedence gap-fill, per field: only when the user gave
+            # ── docstring inference (P1-A Phase 2, opt-in #551) ──────────
+            # Opt-in (#551): docstring inference is off by default so a
+            # handler's prose docstring is never published as public API
+            # documentation without explicit consent. When enabled, it stays
+            # lowest-precedence gap-fill, per field: only when the user gave
             # no explicit ``summary=`` / ``description=``. ``None`` is the
             # "unset" sentinel, so an explicit ``summary=""`` / ``description=""``
             # is an intentional override and suppresses inference for that field.
@@ -587,7 +600,7 @@ def openapi(
             # remainder the description.
             effective_summary = summary or ""
             effective_description = description or ""
-            if summary is None or description is None:
+            if infer_docstring and (summary is None or description is None):
                 inferred_summary, inferred_description = _infer_doc_metadata(metadata_func)
                 if summary is None:
                     effective_summary = inferred_summary

--- a/tests/test_docstring_inference.py
+++ b/tests/test_docstring_inference.py
@@ -1,10 +1,13 @@
-"""Docstring inference (P1-A Phase 2).
+"""Docstring inference (P1-A Phase 2, opt-in via ``infer_docstring=True``, #551).
 
 Covers inferring ``summary``/``description`` from a handler's docstring at both
 decorator-time (``@openapi``) and scan-time (bare ``@app.route``, with or
-without a documentable return annotation). Docstring inference is per-field and
-lowest-precedence source: an explicit ``summary=``/``description=`` always wins,
-and a missing/blank docstring infers nothing.
+without a documentable return annotation). Docstring inference is opt-in and
+OFF by default so a handler's prose docstring never leaks into the published
+spec without explicit consent. When enabled it is a per-field, lowest-
+precedence source: an explicit ``summary=``/``description=`` always wins, and a
+missing/blank docstring infers nothing. Return-type response inference is
+independent and always on.
 """
 
 from __future__ import annotations
@@ -94,12 +97,28 @@ def test_infer_dedents_indented_body() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Decorator-time inference
+# Decorator-time inference (opt-in via infer_docstring=True, #551)
 # ---------------------------------------------------------------------------
 
 
-def test_decorator_infers_summary_and_description() -> None:
+def test_decorator_default_off_ignores_docstring() -> None:
+    # Opt-in (#551): docstring inference is OFF by default, so a handler's
+    # prose docstring must never leak into the published spec without consent.
     @openapi()
+    def get_user(req: Any) -> User:  # pragma: no cover
+        """Get a user.
+
+        Full description here.
+        """
+        raise NotImplementedError
+
+    entry = get_openapi_registry()["get_user"]
+    assert entry["summary"] == ""
+    assert entry["description"] == ""
+
+
+def test_decorator_infers_summary_and_description() -> None:
+    @openapi(infer_docstring=True)
     def get_user(req: Any) -> User:  # pragma: no cover
         """Get a user.
 
@@ -115,7 +134,7 @@ def test_decorator_infers_summary_and_description() -> None:
 def test_explicit_summary_wins_but_description_is_inferred() -> None:
     # Per-field gap fill: an explicit summary is kept while a missing
     # description is still filled from the docstring body.
-    @openapi(summary="Explicit summary")
+    @openapi(summary="Explicit summary", infer_docstring=True)
     def get_user(req: Any) -> User:  # pragma: no cover
         """Doc summary.
 
@@ -129,7 +148,7 @@ def test_explicit_summary_wins_but_description_is_inferred() -> None:
 
 
 def test_explicit_both_win_over_docstring() -> None:
-    @openapi(summary="S", description="D")
+    @openapi(summary="S", description="D", infer_docstring=True)
     def get_user(req: Any) -> User:  # pragma: no cover
         """Doc summary.
 
@@ -143,7 +162,7 @@ def test_explicit_both_win_over_docstring() -> None:
 
 
 def test_decorator_no_docstring_leaves_empty() -> None:
-    @openapi()
+    @openapi(infer_docstring=True)
     def bare(req: Any) -> User:  # pragma: no cover
         raise NotImplementedError
 
@@ -155,7 +174,7 @@ def test_decorator_no_docstring_leaves_empty() -> None:
 def test_explicit_empty_string_suppresses_docstring_inference() -> None:
     # ``None`` is the "unset" sentinel; an explicit ``""`` is an intentional
     # override and must NOT be back-filled from the docstring (#532 review).
-    @openapi(summary="", description="")
+    @openapi(summary="", description="", infer_docstring=True)
     def get_user(req: Any) -> User:  # pragma: no cover
         """Doc summary.
 
@@ -171,7 +190,7 @@ def test_explicit_empty_string_suppresses_docstring_inference() -> None:
 def test_explicit_empty_summary_still_infers_description() -> None:
     # Per-field sentinel: suppressing summary with ``""`` must not stop the
     # description from being inferred (it was left as ``None``).
-    @openapi(summary="")
+    @openapi(summary="", infer_docstring=True)
     def get_user(req: Any) -> User:  # pragma: no cover
         """Doc summary.
 
@@ -185,11 +204,14 @@ def test_explicit_empty_summary_still_infers_description() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Scan-time inference (zero-decorator @app.route)
+# Scan-time inference (zero-decorator @app.route, opt-in #551)
 # ---------------------------------------------------------------------------
 
 
-def test_scan_infers_docstring_for_bare_route() -> None:
+def test_scan_default_off_ignores_docstring_but_keeps_return_inference() -> None:
+    # Opt-in (#551): without ``infer_docstring=True`` the scanner must not
+    # publish the docstring. Return-type response inference is independent and
+    # stays on, so the 200 response model is still registered.
     def get_user(req: Any) -> User:  # pragma: no cover
         """Get a user.
 
@@ -200,6 +222,26 @@ def test_scan_infers_docstring_for_bare_route() -> None:
     scan_endpoint_metadata(_app_for(get_user, name="get_user", route="users", methods=["GET"]))
 
     entry = get_openapi_registry()["get::/api/users"]
+    assert entry["summary"] == ""
+    assert entry["description"] == ""
+    # Return-type inference is unaffected by the docstring opt-in.
+    assert entry.get("response_model") is User
+
+
+def test_scan_infers_docstring_for_bare_route() -> None:
+    def get_user(req: Any) -> User:  # pragma: no cover
+        """Get a user.
+
+        Scan-time description.
+        """
+        raise NotImplementedError
+
+    scan_endpoint_metadata(
+        _app_for(get_user, name="get_user", route="users", methods=["GET"]),
+        infer_docstring=True,
+    )
+
+    entry = get_openapi_registry()["get::/api/users"]
     assert entry["summary"] == "Get a user."
     assert entry["description"] == "Scan-time description."
 
@@ -208,7 +250,10 @@ def test_scan_bare_route_without_docstring_has_empty_metadata() -> None:
     def get_user(req: Any) -> User:  # pragma: no cover
         raise NotImplementedError
 
-    scan_endpoint_metadata(_app_for(get_user, name="get_user", route="users", methods=["GET"]))
+    scan_endpoint_metadata(
+        _app_for(get_user, name="get_user", route="users", methods=["GET"]),
+        infer_docstring=True,
+    )
 
     entry = get_openapi_registry()["get::/api/users"]
     assert entry["summary"] == ""
@@ -226,7 +271,10 @@ def test_scan_infers_docstring_for_bare_route_without_documentable_return() -> N
         """
         raise NotImplementedError
 
-    scan_endpoint_metadata(_app_for(get_user, name="get_user", route="users", methods=["GET"]))
+    scan_endpoint_metadata(
+        _app_for(get_user, name="get_user", route="users", methods=["GET"]),
+        infer_docstring=True,
+    )
 
     entry = get_openapi_registry()["get::/api/users"]
     assert entry["summary"] == "Get a user."
@@ -244,7 +292,10 @@ def test_scan_infers_docstring_for_unannotated_bare_route() -> None:
         """Ping."""
         raise NotImplementedError
 
-    scan_endpoint_metadata(_app_for(get_user, name="get_user", route="users", methods=["GET"]))
+    scan_endpoint_metadata(
+        _app_for(get_user, name="get_user", route="users", methods=["GET"]),
+        infer_docstring=True,
+    )
 
     entry = get_openapi_registry()["get::/api/users"]
     assert entry["summary"] == "Ping."


### PR DESCRIPTION
## Summary
- Docstring inference (`summary`/`description`) was **default-on**, publishing a handler's prose docstring into the generated OpenAPI spec without explicit consent. Since the feature is still unreleased, this makes it **opt-in**.
- Add `infer_docstring: bool = False` to both `@openapi(...)` and `scan_endpoint_metadata(...)` (forwarded through the deprecated `scan_validation_metadata` alias). Docstring metadata is only inferred when the flag is `True`.
- **Return-type response inference stays default-on** — a return *type* is a structural declaration, not free-form prose, so it needs no separate consent gate.

## Behavior
- Default (`infer_docstring=False`): docstrings are ignored; `summary`/`description` register empty unless set explicitly.
- Enabled: unchanged per-field, lowest-precedence gap-fill — explicit value (including `""` suppression) always wins over inference.
- Preserves bare docstring-only route registration (#534) and does **not** set `_response_inferred` when only a docstring is inferred.

## Tests / docs
- Restructured `tests/test_docstring_inference.py`: added default-off assertions (decorator + scan), and a scan test proving return-type inference stays on while docstring is off; flipped the previously default-on cases to pass `infer_docstring=True`.
- Updated `docs/usage.md` and the README feature bullet to document the opt-in.
- `make test` (859 passed, coverage 95.81%), `make lint`, `make typecheck` all clean.

Closes #551