### PR TITLE
fix(ci): run the real matrix interpreter for every test cell

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,13 +10,53 @@ permissions:
   contents: read
 
 jobs:
+  # Lint, type-check and security run once on a single pinned interpreter
+  # (Python 3.10, matching the mypy/ruff target-version in pyproject). These
+  # checks are interpreter-agnostic, so fanning them across the matrix would
+  # only duplicate work.
+  quality:
+    name: Lint, type-check & security (Py 3.10)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Install package with dev extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint workflows (pin hygiene + release-gate canonical SHAs)
+        run: |
+          python tools/lint_release_workflows.py
+          python tools/lint_workflow_pins.py
+
+      - name: Ruff style check
+        run: ruff check src tests
+
+      - name: Type check (mypy, strict)
+        run: mypy src tests
+
+      - name: Security scan (bandit)
+        run: python -m bandit -r src
+
   test:
+    name: Test (Py ${{ matrix.python-version }}, af ${{ matrix.azure-functions-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # Python 3.14 is stable and required in this matrix (not allow-fail).
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # The 1.x line is supported on Python 3.10–3.12 (see the README SDK
+        # Compatibility table). Python 3.13/3.14 are covered by the dedicated,
+        # wheel-based `azure-functions-2x` lane below, because the 2.x line is
+        # the only one installable there. Keeping 3.13/3.14 out of THIS matrix
+        # avoids advertising an untested 1.x × 3.13/3.14 combination.
+        python-version: ["3.10", "3.11", "3.12"]
         # 'latest' resolves whatever satisfies the pyproject.toml pin at CI time.
         azure-functions-version: ["latest"]
         include:
@@ -37,33 +77,65 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Hatch and dependencies via Makefile
+      - name: Assert the runtime interpreter matches the matrix cell
+        # Tests must run on the interpreter this cell claims to exercise. Before
+        # #554 the whole matrix ran through the Python-3.10-pinned hatch env, so
+        # 3.11/3.12 were never actually tested. This guard fails loudly if the
+        # running interpreter ever drifts from matrix.python-version again.
+        env:
+          EXPECTED: ${{ matrix.python-version }}
         run: |
-          pip install hatch
-          make install
+          python - <<'PY'
+          import os, sys
+          expected = tuple(int(p) for p in os.environ["EXPECTED"].split("."))
+          actual = sys.version_info[: len(expected)]
+          assert actual == expected, f"interpreter {actual} != matrix {expected}"
+          print(f"interpreter OK: {sys.version.split()[0]}")
+          PY
+
+      - name: Install package with dev extras (on the matrix interpreter)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
 
       - name: Install azure-functions ${{ matrix.azure-functions-version }}
         run: |
           if [ "${{ matrix.azure-functions-version }}" = "latest" ]; then
             # Mirror the pyproject.toml constraint so 'latest' cannot install azure-functions 2.x when it releases (see README SDK Compatibility).
-            .venv/bin/hatch run pip install --upgrade 'azure-functions>=1.21.0,<2.0.0'
+            pip install --upgrade 'azure-functions>=1.21.0,<2.0.0'
           else
-            .venv/bin/hatch run pip install --upgrade 'azure-functions==${{ matrix.azure-functions-version }}'
+            pip install --upgrade 'azure-functions==${{ matrix.azure-functions-version }}'
           fi
-          .venv/bin/hatch run python -c "import azure.functions, importlib.metadata as m; print('azure-functions installed:', m.version('azure-functions'))"
+          python -c "import azure.functions, importlib.metadata as m; print('azure-functions installed:', m.version('azure-functions'))"
 
       - name: Install azure-functions-validation (run bridge/validation example tests on one cell)
         # These example tests are skipif-guarded on the optional azure-functions-validation
         # import. Install it on a single matrix cell so they actually execute in CI (see #275).
         if: matrix.python-version == '3.12' && matrix.azure-functions-version == 'latest'
         run: |
-          .venv/bin/hatch run pip install --upgrade 'azure-functions-validation>=0.7.0'
-          .venv/bin/hatch run python -c "import azure_functions_validation, importlib.metadata as m; print('azure-functions-validation installed:', m.version('azure-functions-validation'))"
+          pip install --upgrade 'azure-functions-validation>=0.7.0'
+          python -c "import azure_functions_validation, importlib.metadata as m; print('azure-functions-validation installed:', m.version('azure-functions-validation'))"
 
-      - name: Run full quality checks
-        run: make check-all
+      - name: Run tests on the matrix interpreter
+        # Raw pytest on the interpreter provisioned above (NOT through the
+        # Python-3.10-pinned hatch env). The repo pytest config enables --cov
+        # with fail_under=95, but only the 3.10 x latest cell collects the full
+        # suite: other cells skipif-guard optional-dependency tests (e.g. the
+        # azure-functions-validation examples run only on 3.12), so their
+        # coverage is legitimately lower. Enforce the coverage gate on the
+        # canonical 3.10 x latest cell and run the rest with --no-cov so a
+        # version-variant cell cannot fail the build on a spurious coverage dip.
+        env:
+          IS_COVERAGE_CELL: ${{ matrix.python-version == '3.10' && matrix.azure-functions-version == 'latest' }}
+        run: |
+          if [ "$IS_COVERAGE_CELL" = "true" ]; then
+            pytest tests/
+          else
+            pytest tests/ --no-cov
+          fi
 
       - name: Verify coverage output
+        if: matrix.python-version == '3.10' && matrix.azure-functions-version == 'latest'
         run: ls -lh coverage.xml
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
## Context

The `test` job in `ci-test.yml` ran `make install`, which creates the hatch
`default` env — pinned to Python 3.10 via `[tool.hatch.envs.default]` in
`pyproject.toml`. As a result **every matrix cell executed Python 3.10 at
runtime regardless of `matrix.python-version`**, so the 3.11 and 3.12 cells
(and the advertised 1.x × {3.11, 3.12} coverage in the README) were never
actually exercised. The old workflow even admitted this in a comment.

## Changes

- **Split `quality` job** — interpreter-agnostic lint / mypy / bandit + workflow
  pin linters run once on Python 3.10 (matching the mypy/ruff `target-version`).
- **`test` matrix now uses the real interpreter** — provisions
  `matrix.python-version` via `setup-python` and installs the package with plain
  `pip install -e ".[dev]"` (no hatch env), so each cell genuinely runs its
  named Python.
- **Interpreter guard step** — asserts the running interpreter matches
  `matrix.python-version`, failing loudly if this drift is ever reintroduced.
- **Coverage gate scoped** — `fail_under=95` is enforced only on the canonical
  `3.10 × latest` cell; other cells run `--no-cov`, since skipif-guarded
  optional-dependency tests (e.g. the `azure-functions-validation` examples,
  which install only on the 3.12 cell) make their coverage legitimately lower.
- **Dropped 3.13/3.14** from this 1.x matrix — they are unsupported for the 1.x
  line and already covered by the wheel-based `azure-functions-2x` lane.

This makes the README SDK compatibility matrix (1.x × {3.10, 3.11, 3.12}) a
genuinely tested claim rather than an aspirational one.

## Acceptance Checklist

- [x] Each `test` matrix cell runs its named Python interpreter (guard step enforces it)
- [x] Coverage gate enforced on the 3.10 × latest cell; other cells run `--no-cov`
- [x] `tools/lint_release_workflows.py` passes
- [x] `tools/lint_workflow_pins.py` passes (all actions SHA-pinned)
- [x] Workflow YAML parses; jobs = `quality`, `test`, `azure-functions-2x`
- [ ] CI green on this PR across 3.10 / 3.11 / 3.12 + the 1.21.0 / 1.24.0 cells

## References

- Closes #554