### PR TITLE
feat(inference): add infer_return_types opt-out switch (keep default-on)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Spec matches code. Always. Swagger UI out of the box.
 - **Swagger UI** — built-in `/docs` endpoint with security defaults
 - **CLI tooling** — generate specs at build time for CI validation
 - **Schema support** — query, path, header, body, and response schemas
-- **Metadata inference** — infer the `200` response from a handler's return type (always on), and opt into `summary`/`description` inference from its docstring with `infer_docstring=True`; both are gap-fill-only and explicit-always-wins (see [Usage Guide](docs/usage.md#inferred-metadata-return-type--docstring))
+- **Metadata inference** — infer the `200` response from a handler's return type (on by default, opt out with `infer_return_types=False`), and opt into `summary`/`description` inference from its docstring with `infer_docstring=True`; both are gap-fill-only and explicit-always-wins (see [Usage Guide](docs/usage.md#inferred-metadata-return-type--docstring))
 - **`auth_level` security inference** — opt-in `infer_auth_level=True` derives OpenAPI security from a route's Azure Functions `auth_level` (see [Usage Guide](docs/usage.md#infer-security-from-auth_level-opt-in))
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -262,7 +262,7 @@ def get_order(req: func.HttpRequest) -> OrderResponse:  # -> 200 OrderResponse s
   `-> None`, `-> Any`, `-> func.HttpResponse`, bare scalars (`-> str`,
   `-> int`), and unsupported generics.
 - An unresolved forward reference (e.g. under
-`from __future__ import annotations`) simply infers nothing rather than
+  `from __future__ import annotations`) simply infers nothing rather than
   failing.
 
 To suppress return-type inference (for example, when your handler returns an

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -244,7 +244,7 @@ decorator-time (`@openapi`) and scan-time (a bare `@app.route` with no
 ### Return-type inference
 
 When you supply no explicit `responses=`, the handler's return annotation infers
-the `200` response. This inference is always on — a return **type** is a
+the `200` response. This inference is **on by default** — a return **type** is a
 structural declaration, not free-form prose, so publishing it needs no separate
 consent:
 
@@ -262,8 +262,15 @@ def get_order(req: func.HttpRequest) -> OrderResponse:  # -> 200 OrderResponse s
   `-> None`, `-> Any`, `-> func.HttpResponse`, bare scalars (`-> str`,
   `-> int`), and unsupported generics.
 - An unresolved forward reference (e.g. under
-  `from __future__ import annotations`) simply infers nothing rather than
+`from __future__ import annotations`) simply infers nothing rather than
   failing.
+
+To suppress return-type inference (for example, when your handler returns an
+internal transport type you do not want surfaced), opt out per handler with
+`infer_return_types=False` (decorator) or per scan with
+`scan_endpoint_metadata(..., infer_return_types=False)`. This is analogous to
+FastAPI's `response_model=None`. An explicit `responses=` always wins regardless
+of the flag.
 
 ### Docstring inference (opt-in)
 

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -457,6 +457,7 @@ def scan_endpoint_metadata(
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
     registry: OpenAPIRegistry | None = None,
     infer_docstring: bool = False,
+    infer_return_types: bool = True,
 ) -> None:
     """Scan function builders for toolkit metadata and register OpenAPI operations.
 
@@ -482,7 +483,13 @@ def scan_endpoint_metadata(
     ``infer_docstring`` (opt-in, #551): when ``True``, gap-fill
     ``summary``/``description`` from a bare handler's docstring. Off by default
     so a handler's prose docstring is never published without explicit consent.
-    Return-type response inference is independent and always on.
+    Return-type response inference is controlled separately by
+    ``infer_return_types`` (on by default).
+
+    ``infer_return_types`` (default ``True``): gap-fill the ``200`` response
+    schema from a bare handler's return annotation. Set ``False`` to suppress
+    return-type inference entirely (analogous to FastAPI's
+    ``response_model=None``).
     """
     reg = registry if registry is not None else _global_registry
     isolated = reg is not _global_registry
@@ -617,7 +624,8 @@ def scan_endpoint_metadata(
         inferred_summary = ""
         inferred_description = ""
         if canonical_target is None and endpoint_hints is None and not endpoint_skew:
-            inferred_response_model, inferred_response = _infer_response_from_return(handler)
+            if infer_return_types:
+                inferred_response_model, inferred_response = _infer_response_from_return(handler)
             if infer_docstring:
                 inferred_summary, inferred_description = _infer_doc_metadata(handler)
 
@@ -835,6 +843,7 @@ def scan_validation_metadata(
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
     registry: OpenAPIRegistry | None = None,
     infer_docstring: bool = False,
+    infer_return_types: bool = True,
 ) -> None:
     """Deprecated alias for :func:`scan_endpoint_metadata` (forwards ``infer_docstring``).
 
@@ -843,7 +852,8 @@ def scan_validation_metadata(
     ``scan_validation_metadata`` name is a misnomer. Use
     :func:`scan_endpoint_metadata` instead. This alias forwards unchanged and
     will be removed in a future minor release. The opt-in ``infer_docstring``
-    flag is forwarded unchanged to :func:`scan_endpoint_metadata`.
+    flag is forwarded unchanged to :func:`scan_endpoint_metadata`, as is
+    ``infer_return_types`` (on by default).
     """
     warnings.warn(
         "scan_validation_metadata() is deprecated; use scan_endpoint_metadata() "
@@ -852,5 +862,9 @@ def scan_validation_metadata(
         stacklevel=2,
     )
     scan_endpoint_metadata(
-        app, route_prefix, registry=registry, infer_docstring=infer_docstring
+        app,
+        route_prefix,
+        registry=registry,
+        infer_docstring=infer_docstring,
+        infer_return_types=infer_return_types,
     )

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -365,6 +365,7 @@ def openapi(
     querystring_media_type: str = "application/x-www-form-urlencoded",
     # ── inference toggles ─────────────────────────────────────────
     infer_docstring: bool = False,
+    infer_return_types: bool = True,
 ) -> Callable[[F], F]:
     """
     Decorator that attaches OpenAPI metadata to an Azure Functions handler.
@@ -490,7 +491,15 @@ def openapi(
         from the handler's docstring for any of those fields left unset
         (``None``). Defaults to ``False`` so a handler's prose docstring is
         never published as public API documentation without explicit consent.
-        Return-type response inference is independent and always on.
+        Return-type response inference is controlled separately by
+        ``infer_return_types`` (on by default).
+    infer_return_types:
+        When ``True`` (default), gap-fill the ``200`` response schema from the
+        handler's return annotation whenever no explicit ``responses=`` is
+        supplied. Set ``False`` to suppress return-type inference entirely
+        (analogous to FastAPI's ``response_model=None``);
+        an explicit
+        ``responses=`` always wins regardless of this flag.
 
     Returns
     -------
@@ -579,7 +588,7 @@ def openapi(
             # scan-time validation/explicit metadata can supersede it (Oracle
             # precedence: explicit > validation > inference).
             response_inferred = False
-            if responses is None:
+            if responses is None and infer_return_types:
                 inferred_model, inferred_response = _infer_response_from_return(metadata_func)
                 if inferred_model is not None:
                     resolved_response_model = inferred_model

--- a/tests/test_return_type_inference.py
+++ b/tests/test_return_type_inference.py
@@ -275,3 +275,83 @@ def test_merge_validation_supersedes_inferred_response_dict() -> None:
 
     assert existing["response"][200]["description"] == "Validated"
     assert "_response_inferred" not in existing
+
+
+
+# ---------------------------------------------------------------------------
+# Opt-out switch: infer_return_types (#556)
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_opt_out_skips_return_inference() -> None:
+    # infer_return_types=False suppresses return-type inference entirely, even
+    # when the handler declares a documentable return annotation.
+    @openapi(summary="Get a user", infer_return_types=False)
+    def get_user(req: Any) -> User:  # pragma: no cover
+        raise NotImplementedError
+
+    entry = get_openapi_registry()["get_user"]
+    assert entry["response_model"] is None
+    assert entry["response"] == {}
+    assert entry["_response_inferred"] is False
+
+
+def test_decorator_default_still_infers_return() -> None:
+    # Default (infer_return_types=True) preserves 0.25.0 behavior.
+    @openapi(summary="Get a user")
+    def get_user(req: Any) -> User:  # pragma: no cover
+        raise NotImplementedError
+
+    entry = get_openapi_registry()["get_user"]
+    assert entry["response_model"] is User
+    assert entry["_response_inferred"] is True
+
+
+def test_decorator_opt_out_leaves_explicit_responses_intact() -> None:
+    # Explicit responses= still wins regardless of the opt-out flag.
+    @openapi(summary="Create", responses=Other, infer_return_types=False)
+    def create(req: Any) -> User:  # pragma: no cover
+        raise NotImplementedError
+
+    entry = get_openapi_registry()["create"]
+    assert entry["response_model"] is Other
+    assert entry["_response_inferred"] is False
+
+
+def test_scan_opt_out_skips_return_inference_for_bare_route() -> None:
+    def get_user(req: Any) -> User:  # pragma: no cover
+        raise NotImplementedError
+
+    scan_endpoint_metadata(
+        _app_for(get_user, name="get_user", route="users", methods=["GET"]),
+        infer_return_types=False,
+    )
+
+    # With inference off and no other metadata, the bare route registers nothing.
+    assert "get::/api/users" not in get_openapi_registry()
+
+
+def test_scan_default_still_infers_for_bare_route() -> None:
+    def get_user(req: Any) -> User:  # pragma: no cover
+        raise NotImplementedError
+
+    scan_endpoint_metadata(_app_for(get_user, name="get_user", route="users", methods=["GET"]))
+
+    entry = get_openapi_registry()["get::/api/users"]
+    assert entry["response_model"] is User
+    assert entry["_response_inferred"] is True
+
+
+def test_scan_validation_metadata_forwards_infer_return_types() -> None:
+    from azure_functions_openapi.bridge import scan_validation_metadata
+
+    def get_user(req: Any) -> User:  # pragma: no cover
+        raise NotImplementedError
+
+    with pytest.warns(DeprecationWarning):
+        scan_validation_metadata(
+            _app_for(get_user, name="get_user", route="users", methods=["GET"]),
+            infer_return_types=False,
+        )
+
+    assert "get::/api/users" not in get_openapi_registry()


### PR DESCRIPTION
## Summary

Adds an opt-out switch for return-type inference so users can suppress auto-inferred `200` response schemas while keeping the current 0.25.0 default behavior unchanged.

- New parameter `infer_return_types: bool = True` on `@openapi` and `scan_endpoint_metadata` (forwarded through the deprecated `scan_validation_metadata` alias).
- `True` (default) preserves 0.25.0 behavior: the `200` schema is gap-filled from the handler's return annotation when no explicit `responses=` is given.
- `False` skips `_infer_response_from_return` entirely — analogous to FastAPI's `response_model=None`. An explicit `responses=` still always wins regardless of the flag.
- Docstring inference (`infer_docstring`) semantics are untouched.

## Changes

- `decorator.py`: signature param + Args docs; gate `if responses is None and infer_return_types:`.
- `bridge.py`: `scan_endpoint_metadata` param + docs; scan-time gate `if infer_return_types:` (docstring inference stays independently gated); `scan_validation_metadata` forwards the flag.
- Tests: opt-out at decorator + scan level, default-still-infers, explicit-responses-win, and alias forwarding.
- Docs: `docs/usage.md` doctrine section + README inference bullet updated ("always on" → "on by default, opt out with `infer_return_types=False`").

## Verification

- `make lint` clean, `make typecheck` clean (mypy strict, 59 files).
- Full suite green; coverage 95.81% (gate ≥95%).

Closes #556