### PR TITLE
fix(inference): lock Optional[T]-return 200 semantics — flatten to plain T (#558)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -256,8 +256,15 @@ def get_order(req: func.HttpRequest) -> OrderResponse:  # -> 200 OrderResponse s
 ```
 
 - `-> User` (a Pydantic `BaseModel`) → `200` response with the model schema.
-- `-> list[User]` / `Optional[User]` → the same array / union shorthand as an
-  explicit `responses=` shorthand.
+- `-> list[User]` → the same array shorthand as an explicit `responses=`
+  shorthand.
+- `-> Optional[User]` (i.e. `Union[User, None]`) → the bare `User` schema. A
+  nullable **return** is read as "the handler may or may not produce a value",
+  not as a `200` body that is literally JSON `null`, so the root `None` branch
+  is dropped and the emitted `200` is identical under OpenAPI 3.0 and 3.1. To
+  document a genuinely nullable body, declare it explicitly with `responses=`.
+  Nested nullability is preserved: `-> list[Optional[User]]` keeps nullable
+  array items.
 - Non-documentable returns infer **nothing** (no `200` is fabricated):
   `-> None`, `-> Any`, `-> func.HttpResponse`, bare scalars (`-> str`,
   `-> int`), and unsupported generics.

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -16,6 +16,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_args,
     get_origin,
     get_type_hints,
 )
@@ -197,6 +198,35 @@ def _is_supported_shorthand_generic(value: Any) -> bool:
     return origin is Union or origin is types.UnionType
 
 
+def _flatten_optional_root(hint: Any) -> Any:
+    """Drop the ``None`` branch from a top-level ``Optional[T]`` return annotation.
+
+    Return-type inference treats an ``Optional[T]`` / ``Union[T, None]`` *return*
+    as "the handler may or may not produce a value", not as a contract promising a
+    literal JSON ``null`` 200 body. So at the response root we flatten to the
+    non-``None`` member(s) (#558): ``Optional[User]`` -> ``User``,
+    ``Union[A, B, None]`` -> ``Union[A, B]``. This keeps the inferred 200 schema
+    valid under both OpenAPI 3.0 and 3.1 (no top-level ``{"type": "null"}``) and
+    identical across versions.
+
+    Nested nullability is deliberately preserved: only the *root* union is
+    unwrapped here, so ``list[Optional[User]]`` keeps its nullable items — there
+    the ``None`` describes the real JSON shape of array elements.
+
+    A non-union hint, or a union with no ``None`` branch, is returned unchanged.
+    A union of *only* ``None`` collapses to ``NoneType`` (not documentable).
+    """
+    origin = get_origin(hint)
+    if origin is not Union and origin is not types.UnionType:
+        return hint
+    non_none = [arg for arg in get_args(hint) if arg is not type(None)]
+    if not non_none:
+        return type(None)
+    if len(non_none) == 1:
+        return non_none[0]
+    return Union[tuple(non_none)]
+
+
 def _normalize_unified_responses(
     responses: Mapping[Any, Any], func_name: str
 ) -> dict[int | str, dict[str, Any]]:
@@ -307,6 +337,11 @@ def _infer_response_from_return(
         # instead resolved to ``type(None)`` by ``get_type_hints`` and falls
         # through to the not-documentable branch below.)
         return None, None
+
+    # Flatten a top-level ``Optional[T]`` / ``Union[..., None]`` return to its
+    # non-``None`` member(s) before classifying it, so the inferred 200 body is
+    # the model itself rather than a nullable ``anyOf`` (#558).
+    hint = _flatten_optional_root(hint)
 
     if _is_pydantic_model(hint):
         return hint, None

--- a/tests/test_return_type_inference.py
+++ b/tests/test_return_type_inference.py
@@ -9,7 +9,7 @@ supersede it, and it must never raise on unresolved annotations.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from _scan_helpers import _app_for
 from pydantic import BaseModel
@@ -27,6 +27,7 @@ from azure_functions_openapi.decorator import (
     get_openapi_registry,
     openapi,
 )
+from azure_functions_openapi.spec import generate_openapi_spec
 
 
 @pytest.fixture(autouse=True)
@@ -69,13 +70,15 @@ def test_infer_container_generic_return() -> None:
     assert response[200]["content"]["application/json"]["schema"] == list[User]
 
 
-def test_infer_optional_return_is_union_shorthand() -> None:
+def test_infer_optional_return_flattens_to_model() -> None:
+    # ``Optional[User]`` is treated as "may or may not produce a value", so the
+    # inferred 200 body is the model itself — not a nullable ``anyOf`` (#558).
     def handler(req: Any) -> Optional[User]:  # pragma: no cover
         raise NotImplementedError
 
     model, response = _infer_response_from_return(handler)
-    assert model is None
-    assert response is not None
+    assert model is User
+    assert response is None
 
 
 @pytest.mark.parametrize(
@@ -275,3 +278,65 @@ def test_merge_validation_supersedes_inferred_response_dict() -> None:
 
     assert existing["response"][200]["description"] == "Validated"
     assert "_response_inferred" not in existing
+
+
+# ---------------------------------------------------------------------------
+# Optional[T]-return 200 semantics (#558) — root flatten, nested preserved
+# ---------------------------------------------------------------------------
+
+
+def test_infer_union_return_drops_only_the_none_branch() -> None:
+    # A multi-member union keeps its non-``None`` members but drops ``None`` at
+    # the response root (#558).
+    def handler(req: Any) -> Union[User, Other, None]:  # pragma: no cover
+        raise NotImplementedError
+
+    model, response = _infer_response_from_return(handler)
+    assert model is None
+    assert response is not None
+    schema = response[200]["content"]["application/json"]["schema"]
+    assert schema == Union[User, Other]
+
+
+def test_infer_list_of_optional_preserves_nested_shape() -> None:
+    # Only the *root* union is unwrapped; nested nullability describes the real
+    # JSON shape of array elements and is preserved (#558).
+    def handler(req: Any) -> list[Optional[User]]:  # pragma: no cover
+        raise NotImplementedError
+
+    model, response = _infer_response_from_return(handler)
+    assert model is None
+    assert response is not None
+    assert response[200]["content"]["application/json"]["schema"] == list[Optional[User]]
+
+
+def _spec_response_schema(route: str, openapi_version: str) -> Any:
+    spec = generate_openapi_spec(openapi_version=openapi_version)
+    responses = spec["paths"][route]["get"]["responses"]
+    return responses["200"]["content"]["application/json"]["schema"]
+
+
+@pytest.mark.parametrize("openapi_version", ["3.0.0", "3.1.0"])
+def test_optional_return_emits_plain_model_ref_in_spec(openapi_version: str) -> None:
+    # ``Optional[User]`` renders as the bare model ``$ref`` — identical across
+    # OpenAPI 3.0 and 3.1, with no top-level ``{"type": "null"}`` (#558).
+    @openapi(summary="opt", route="/opt", method="get")
+    def handler(req: Any) -> Optional[User]:  # pragma: no cover
+        raise NotImplementedError
+
+    schema = _spec_response_schema("/api/opt", openapi_version)
+    assert schema == {"$ref": "#/components/schemas/User"}
+
+
+def test_list_of_optional_return_keeps_nullable_items_in_3_1() -> None:
+    # In OpenAPI 3.1, nullable array items are the faithful, valid shape (#558).
+    @openapi(summary="listopt", route="/listopt", method="get")
+    def handler(req: Any) -> list[Optional[User]]:  # pragma: no cover
+        raise NotImplementedError
+
+    schema = _spec_response_schema("/api/listopt", "3.1.0")
+    assert schema["type"] == "array"
+    assert schema["items"]["anyOf"] == [
+        {"$ref": "#/components/schemas/User"},
+        {"type": "null"},
+    ]


### PR DESCRIPTION
## Summary
Locks the inferred `200` schema semantics for `Optional[T]` return annotations (was unpinned; only `is not None` was asserted).

- **Root flatten:** `-> Optional[T]` / `Union[..., None]` now infers the non-`None` member(s) at the `200` root. `-> Optional[User]` emits `{"$ref": ".../User"}`; `-> Union[User, Order, None]` emits `anyOf:[User, Order]`. A nullable **return** means "the handler may or may not produce a value", not a `200` body that is literally JSON `null` — users who want that declare it explicitly via `responses=`.
- **Version-agnostic + valid:** the root schema is now identical under OpenAPI 3.0 and 3.1, eliminating the previously-emitted top-level `{"type": "null"}` that is **invalid** under 3.0.
- **Nested nullability preserved:** only the *root* union is unwrapped — `-> list[Optional[User]]` keeps nullable array items (correct JSON shape) in 3.1.

New helper `_flatten_optional_root` drops the root `None` branch before classification in `_infer_response_from_return`.

## Behavior change
For OpenAPI **3.1** users, a bare `-> Optional[T]` root that previously rendered `anyOf:[T, null]` now renders plain `T`. This is a spec-output change (documented in `docs/usage.md`).

## Out of scope
Nested container nullability under OpenAPI **3.0** (e.g. `list[Optional[T]]` still emits `type:null` in 3.0) is a broader, pre-existing resolver concern that also affects explicit `responses=` and needs a shared 3.1→3.0 downconverter. Split out to **#562**.

## Tests
Added unit + spec-level pins: `Optional[User]` → plain `$ref` in 3.0 **and** 3.1; `Union[A,B,None]` → null dropped; `list[Optional[User]]` → nested nullability preserved (unit + 3.1 spec). Replaced the weak `test_infer_optional_return_is_union_shorthand`.

## Validation
`make lint` clean, `make typecheck` clean, full suite **864 passed / 6 skipped**, coverage **95.77%** (>=95% gate). No new warnings from this package.

Closes #558