### PR TITLE
docs: sync README/docs/llms + CI comments with 0.25.x (OpenAPI 3.2, Pydantic-required)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -155,11 +155,10 @@ jobs:
   # pulls `azure-functions>=2,<3` and runs the full quality suite against the
   # 2.x SDK on real Python 3.13 AND 3.14 interpreters.
   #
-  # Why a wheel + dedicated job (not the main matrix): the hatch `default` env is
-  # pinned to Python 3.10 in pyproject, so every cell of the `test` matrix runs
-  # Python 3.10 at runtime regardless of its `python-version`. Only this
-  # non-hatch, wheel-installed lane genuinely exercises 3.13/3.14, which is
-  # exactly where azure-functions 2.x (Requires-Python >=3.13) is installable.
+  # Why a wheel + dedicated job (not the main matrix): azure-functions 2.x
+  # declares Requires-Python >=3.13, so it is only installable on 3.13/3.14 --
+  # interpreters the main `test` matrix (3.10-3.12) never covers. This lane
+  # installs the built wheel directly (no hatch env) on real 3.13 AND 3.14
   #
   # Gating: this lane runs on every PR as a VISIBLE compatibility signal. The
   # pyproject cap is interpreter-aware (2.x is allowed on Python 3.13+), and the
@@ -197,10 +196,11 @@ jobs:
         run: pip install "$(ls dist/azure_functions_openapi-*.whl)[dev]"
 
       - name: Upgrade azure-functions to the 2.x line
-        # pyproject caps azure-functions <2.0.0 until 2.x is certified on real
-        # Azure. This lane deliberately overrides that cap to PROVE the package
-        # (route discovery adapter, spec generation) still builds and passes its
-        # suite under 2.x. pip warns about the intentional override; expected.
+        # pyproject's azure-functions cap is interpreter-aware: <2.0.0 on Python
+        # <3.13 and <3.0.0 on Python 3.13+ (2.x is certified on real Azure). On
+        # the 3.13/3.14 interpreters this lane runs, 2.x is already permitted; the
+        # explicit >=2,<3 install just pins the 2.x line under test. pip may warn
+        # about resolving to 2.x; expected.
         run: pip install "azure-functions>=2,<3"
 
       - name: Show resolved versions

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     )
 ```
 
-> **Pydantic v2 is optional.** `requests=` / `responses=` are the recommended path, but you can pass raw JSON Schema dicts instead (see below) if you'd rather not add a dependency.
+> **Pydantic v2 is a required dependency** (`pydantic>=2.0,<3.0`) and is installed with this package. `requests=` / `responses=` accept Pydantic models (the recommended path) **or** raw JSON Schema dicts (see below) — so you can describe schemas without authoring Pydantic models, but Pydantic itself is always present.
 
 > **Want runtime validation too? (optional)** `@openapi` documents your Pydantic models — it does not parse or validate requests at runtime. If you also want automatic request parsing, consistent `400`/`422` error responses, and response-model enforcement, layer [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python)'s `@validate_http` on the **same** Pydantic models. It is an optional companion, not a dependency — this package works fully on its own. See the [validation README](https://github.com/yeongseon/azure-functions-validation-python#readme) for details, or a full runnable example that pairs both on one resource: [Full Stack CRUD API](https://github.com/yeongseon/azure-functions-cookbook-python/tree/main/examples/apis-and-ingress/full_stack_crud_api).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 ## Why teams use it
 
 - Keep API docs close to function code with `@openapi`
-- Generate OpenAPI 3.0.0 or 3.1.0 from runtime metadata
+- Generate OpenAPI 3.0.0, 3.1.0, or 3.2.0 from runtime metadata
 - Serve JSON, YAML, and Swagger UI from the same Function App
 - Reuse Pydantic models for both request/response contracts and docs
 - Merge operation-level and global security schemes into one spec
@@ -130,7 +130,7 @@ Generate programmatically with:
 | --- | --- |
 | Python | 3.10 to 3.14 |
 | Azure Functions model | Python v2 (`func.FunctionApp`) |
-| OpenAPI versions | 3.0.0 and 3.1.0 |
+| OpenAPI versions | 3.0.0, 3.1.0, and 3.2.0 |
 | Pydantic | v2 (≥2.0) |
 
 !!! warning

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5,7 +5,7 @@
 ## Package Info
 
 - PyPI: `pip install azure-functions-openapi`
-- Version: 0.16.0
+- Version: 0.25.0
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.dev/azure-functions-python/openapi/
@@ -35,6 +35,7 @@ from azure_functions_openapi import (
     OpenAPISpecConfigError,
     OPENAPI_VERSION_3_0,
     OPENAPI_VERSION_3_1,
+    OPENAPI_VERSION_3_2,
 )
 ```
 
@@ -256,6 +257,7 @@ class OpenAPISpecConfigError(ValueError):
 ```python
 OPENAPI_VERSION_3_0 = "3.0.0"
 OPENAPI_VERSION_3_1 = "3.1.0"
+OPENAPI_VERSION_3_2 = "3.2.0"
 ```
 
 ## Common Patterns
@@ -406,7 +408,7 @@ def openapi_yaml(req: func.HttpRequest) -> func.HttpResponse:
 2. **Pydantic-native**: Models = schema (Pydantic models auto-convert to JSON Schema)
 3. **Registry-based**: All metadata collected in global registry, generated on-demand
 4. **Security-first**: Swagger UI includes CSP and HSTS headers by default
-5. **OpenAPI standard**: Compliant with OpenAPI 3.0.0 and 3.1.0 specs
+5. **OpenAPI standard**: Compliant with OpenAPI 3.0.0, 3.1.0, and 3.2.0 specs
 6. **No code generation**: Specs are generated at runtime (no static codegen step)
 
 ## Limitations

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,7 @@
 ## Package Info
 
 - PyPI: `pip install azure-functions-openapi`
-- Version: 0.16.0
+- Version: 0.25.0
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.dev/azure-functions-python/openapi/
@@ -14,7 +14,7 @@
 ## What It Does
 
 Declarative OpenAPI documentation for Azure Functions v2. Attach metadata via
-`@openapi()` decorator or programmatically. Generates OpenAPI 3.0/3.1 specs in JSON/YAML.
+`@openapi()` decorator or programmatically. Generates OpenAPI 3.0/3.1/3.2 specs in JSON/YAML.
 Renders Swagger UI with enterprise security headers (CSP, HSTS).
 
 ## Core API
@@ -28,7 +28,7 @@ Renders Swagger UI with enterprise security headers (CSP, HSTS).
 - `render_swagger_ui(title, openapi_url, ...)` — Render Swagger UI HTML
 - `OpenAPIOperationMetadata` — Type for operation metadata
 - `OpenAPISpecConfigError` — Exception for configuration errors
-- `OPENAPI_VERSION_3_0`, `OPENAPI_VERSION_3_1` — Version constants
+- `OPENAPI_VERSION_3_0`, `OPENAPI_VERSION_3_1`, `OPENAPI_VERSION_3_2` — Version constants
 - `scan_endpoint_metadata(app)` — Auto-discover @validate_http metadata and register in OpenAPI registry
 
 ## Quick Start


### PR DESCRIPTION
## Summary
Resolves documentation drift that accumulated on `main` after the 0.25.x work landed. All changes are docs/comments only — no runtime or public-API behavior changes.

- **README.md**: Rewrote the Pydantic note (L249) to state Pydantic v2 is a **required, installed** dependency (`pydantic>=2.0,<3.0`), instead of contradicting the L122 "requires Pydantic v2" line. Raw JSON Schema dicts remain an alternative to authoring Pydantic *models*, not a way to avoid the dependency.
- **docs/index.md**: Added the already-exported OpenAPI **3.2.0** to the supported-versions lines (L11, L133), which previously listed only 3.0/3.1.
- **llms.txt / llms-full.txt**: Bumped `Version` from the stale `0.16.0` to `0.25.0`, added `3.2` to the version list, and added the `OPENAPI_VERSION_3_2 = "3.2.0"` constant to the exported-constants blocks.
- **.github/workflows/ci-test.yml**: Refreshed two stale rationale comments — the wheel-lane comment (previously "every cell runs Python 3.10", false since #555) and the dependency-cap comment (previously "<2.0.0 until 2.x certified"; now the interpreter-aware `<3.0.0` cap with certification).

## Verification
- `make lint` — clean
- `make lint-workflows` — clean
- Full test suite — 0 failures (no docs-consistency tests exist)
- YAML validity confirmed for `ci-test.yml`

Closes #566
Closes #567