### PR TITLE
fix(spec): down-convert nested container nullability to valid OpenAPI 3.0 (#562)

### DIFF
--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -1,6 +1,7 @@
 # src/azure_functions_openapi/spec.py
 from __future__ import annotations
 
+from collections.abc import Callable
 import copy
 from dataclasses import dataclass, field
 import json
@@ -185,6 +186,147 @@ def _convert_schemas_to_3_1(schemas: dict[str, Any]) -> dict[str, Any]:
     """Convert all schemas in components to OpenAPI 3.1 format."""
     return {name: _convert_schema_to_3_1(schema) for name, schema in schemas.items()}
 
+# Keywords whose presence on BOTH an ``anyOf`` wrapper node and its sole non-null
+# member makes an up-merge ambiguous: they constrain validation, so a conflict
+# must not be silently resolved. Annotation-only keys (description/title/...) are
+# safe to overlay and are intentionally excluded.
+_STRUCTURAL_MERGE_KEYS: frozenset[str] = frozenset(
+    {
+        "type",
+        "format",
+        "items",
+        "properties",
+        "enum",
+        "required",
+        "additionalProperties",
+        "allOf",
+        "anyOf",
+        "oneOf",
+        "pattern",
+        "minimum",
+        "maximum",
+        "minLength",
+        "maxLength",
+        "minItems",
+        "maxItems",
+        "multipleOf",
+    }
+)
+
+
+def _collapse_nullable_combinator(schema: dict[str, Any]) -> dict[str, Any]:
+    """Collapse a Pydantic ``anyOf``/``oneOf`` nullable union into OpenAPI 3.0 form.
+
+    OpenAPI 3.0 has no ``{"type": "null"}`` and cannot mark a ``$ref`` nullable
+    inline. Pydantic v2 emits ``Optional[T]`` as
+    ``{"anyOf": [<T>, {"type": "null"}]}``; this rewrites that node to the 3.0
+    ``nullable: true`` idiom (#562):
+
+    * single ``$ref`` member -> ``{"allOf": [<ref>], "nullable": true}`` (a
+      ``$ref`` must not carry sibling keys in 3.0, so it is wrapped).
+    * single inline member -> the member's keys merged up (existing node keys
+      such as ``description`` win) + ``nullable: true``.
+    * multiple members -> the combinator is kept (null member removed) with a
+      sibling ``nullable: true``.
+
+    Nodes without a null-bearing ``anyOf``/``oneOf`` are returned unchanged.
+    """
+    result = schema
+    for key in ("anyOf", "oneOf"):
+        members = result.get(key)
+        if not isinstance(members, list):
+            continue
+        if not any(isinstance(m, dict) and m.get("type") == "null" for m in members):
+            continue
+        non_null = [m for m in members if not (isinstance(m, dict) and m.get("type") == "null")]
+        result = {k: v for k, v in result.items() if k != key}
+        result["nullable"] = True
+        if len(non_null) == 1:
+            sole = non_null[0]
+            if isinstance(sole, dict) and "$ref" in sole:
+                # A $ref must not carry sibling keys in 3.0; wrap the bare ref in
+                # ``allOf`` and lift any annotation siblings up to this node.
+                result["allOf"] = [{"$ref": sole["$ref"]}]
+                for k, v in sole.items():
+                    if k != "$ref":
+                        result.setdefault(k, v)
+            elif isinstance(sole, dict):
+                conflict = any(
+                    k in result and result[k] != v
+                    for k, v in sole.items()
+                    if k in _STRUCTURAL_MERGE_KEYS
+                )
+                if conflict:
+                    # Ambiguous structural overlap: keep the (single-member)
+                    # combinator rather than silently dropping a constraint.
+                    result[key] = [sole]
+                else:
+                    for k, v in sole.items():
+                        result.setdefault(k, v)
+            else:
+                result[key] = non_null
+        elif len(non_null) > 1:
+            result[key] = non_null
+    return result
+
+
+def _convert_schema_to_3_0(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively down-convert a JSON-Schema-2020-12 schema to OpenAPI 3.0.
+
+    Mirrors :func:`_convert_schema_to_3_1` in reverse: the 3.1/Pydantic
+    nullability idioms (``type: [T, "null"]`` and ``anyOf: [T, {type: null}]``)
+    are rewritten to the 3.0 ``nullable: true`` form so the emitted schema is
+    valid under OpenAPI 3.0 (#562). Non-nullable schemas pass through unchanged.
+    """
+    if not isinstance(schema, dict):
+        return schema
+
+    result = dict(schema)
+
+    # ``type: [T, "null"]`` -> ``type: T`` + ``nullable: true``. OpenAPI 3.0
+    # requires ``type`` to be a single string, so a multi-type union is expressed
+    # as ``anyOf`` of single-type schemas rather than a (3.0-invalid) type array.
+    type_val = result.get("type")
+    if isinstance(type_val, list) and "null" in type_val:
+        non_null_types = [t for t in type_val if t != "null"]
+        result["nullable"] = True
+        if len(non_null_types) == 1:
+            result["type"] = non_null_types[0]
+        elif not non_null_types:
+            del result["type"]
+        else:
+            del result["type"]
+            result["anyOf"] = [{"type": t} for t in non_null_types]
+
+    # ``enum: [None, ...]`` -> drop the null member + ``nullable: true``.
+    enum_val = result.get("enum")
+    if isinstance(enum_val, list) and None in enum_val:
+        result["enum"] = [e for e in enum_val if e is not None]
+        result["nullable"] = True
+
+    # Recurse into nested structures first so inner unions are converted before
+    # the combinator at this level is collapsed.
+    if "properties" in result and isinstance(result["properties"], dict):
+        result["properties"] = {
+            k: _convert_schema_to_3_0(v) for k, v in result["properties"].items()
+        }
+    if "items" in result:
+        result["items"] = _convert_schema_to_3_0(result["items"])
+    for combinator in ("allOf", "anyOf", "oneOf"):
+        if combinator in result and isinstance(result[combinator], list):
+            result[combinator] = [_convert_schema_to_3_0(s) for s in result[combinator]]
+    if "additionalProperties" in result and isinstance(result["additionalProperties"], dict):
+        result["additionalProperties"] = _convert_schema_to_3_0(result["additionalProperties"])
+    if "$defs" in result and isinstance(result["$defs"], dict):
+        result["$defs"] = {k: _convert_schema_to_3_0(v) for k, v in result["$defs"].items()}
+
+    return _collapse_nullable_combinator(result)
+
+
+def _convert_schemas_to_3_0(schemas: dict[str, Any]) -> dict[str, Any]:
+    """Down-convert all component schemas to OpenAPI 3.0 nullable form (#562)."""
+    return {name: _convert_schema_to_3_0(schema) for name, schema in schemas.items()}
+
 
 def _has_3_1_only_constructs(schema: dict[str, Any]) -> bool:
     """Check if a schema contains constructs incompatible with OpenAPI 3.0.
@@ -249,13 +391,16 @@ def _check_schemas_3_0_compatible(schemas: dict[str, Any], strict: bool) -> list
     return warnings
 
 
-def _convert_operation_schemas_to_3_1(paths: dict[str, Any]) -> dict[str, Any]:
-    """Apply 3.1 schema conversion to inline schemas in operations.
+def _convert_operation_schemas(
+    paths: dict[str, Any],
+    converter: Callable[[dict[str, Any]], dict[str, Any]],
+) -> dict[str, Any]:
+    """Apply *converter* to every inline schema in operations, in place.
 
     Converts schemas in:
     - requestBody.content.*.schema
     - responses.*.content.*.schema and .itemSchema
-    - parameters[].schema
+    - parameters[].schema (and querystring parameters' content.*.schema)
     """
     for _path, methods in paths.items():
         for _method, operation in methods.items():
@@ -269,7 +414,7 @@ def _convert_operation_schemas_to_3_1(paths: dict[str, Any]) -> dict[str, Any]:
                 if isinstance(content, dict):
                     for _media, media_obj in content.items():
                         if isinstance(media_obj, dict) and "schema" in media_obj:
-                            media_obj["schema"] = _convert_schema_to_3_1(media_obj["schema"])
+                            media_obj["schema"] = converter(media_obj["schema"])
 
             # responses
             responses = operation.get("responses")
@@ -284,7 +429,7 @@ def _convert_operation_schemas_to_3_1(paths: dict[str, Any]) -> dict[str, Any]:
                                 continue
                             for _schema_key in _MEDIA_SCHEMA_KEYS:
                                 if _schema_key in media_obj:
-                                    media_obj[_schema_key] = _convert_schema_to_3_1(
+                                    media_obj[_schema_key] = converter(
                                         media_obj[_schema_key]
                                     )
 
@@ -293,16 +438,26 @@ def _convert_operation_schemas_to_3_1(paths: dict[str, Any]) -> dict[str, Any]:
                 if not isinstance(param, dict):
                     continue
                 if "schema" in param:
-                    param["schema"] = _convert_schema_to_3_1(param["schema"])
+                    param["schema"] = converter(param["schema"])
                 # querystring parameters (OpenAPI 3.2) carry a content map
                 # instead of a bare schema.
                 param_content = param.get("content")
                 if isinstance(param_content, dict):
                     for _media, media_obj in param_content.items():
                         if isinstance(media_obj, dict) and "schema" in media_obj:
-                            media_obj["schema"] = _convert_schema_to_3_1(media_obj["schema"])
+                            media_obj["schema"] = converter(media_obj["schema"])
 
     return paths
+
+
+def _convert_operation_schemas_to_3_1(paths: dict[str, Any]) -> dict[str, Any]:
+    """Apply 3.1 schema conversion to inline schemas in operations."""
+    return _convert_operation_schemas(paths, _convert_schema_to_3_1)
+
+
+def _convert_operation_schemas_to_3_0(paths: dict[str, Any]) -> dict[str, Any]:
+    """Down-convert inline operation schemas to valid OpenAPI 3.0 form (#562)."""
+    return _convert_operation_schemas(paths, _convert_schema_to_3_0)
 
 
 # Media Type Object keys (OpenAPI 3.2 adds ``itemSchema`` for sequential/
@@ -737,6 +892,12 @@ def generate_openapi_spec(
         if openapi_version in (OPENAPI_VERSION_3_1, OPENAPI_VERSION_3_2):
             spec["info"]["summary"] = title
             _convert_operation_schemas_to_3_1(paths)
+        elif openapi_version == OPENAPI_VERSION_3_0:
+            # Down-convert path-level inline schemas (inferred and explicit
+            # ``responses=``/``requests=``) so nested Pydantic nullability is
+            # emitted as valid 3.0 ``nullable: true`` rather than the 3.1-only
+            # ``anyOf: [T, {type: null}]`` idiom (#562).
+            _convert_operation_schemas_to_3_0(paths)
 
         # Top-level and info metadata passthrough (#494). Each field is emitted
         # only when supplied; contact/license nest under ``info`` while
@@ -790,6 +951,11 @@ def generate_openapi_spec(
             if openapi_version in (OPENAPI_VERSION_3_1, OPENAPI_VERSION_3_2):
                 components["schemas"] = _convert_schemas_to_3_1(components["schemas"])
             elif openapi_version == OPENAPI_VERSION_3_0:
+                # Down-convert nullable component schemas to valid 3.0 form
+                # (#562) before the compatibility audit, so faithfully
+                # convertible nullability no longer trips the warn/strict path.
+                components["schemas"] = _convert_schemas_to_3_0(components["schemas"])
+                compat_warnings = _check_schemas_3_0_compatible(components["schemas"], strict)
                 compat_warnings = _check_schemas_3_0_compatible(components["schemas"], strict)
                 for w in compat_warnings:
                     logger.warning("OpenAPI 3.0 compatibility: %s", w)

--- a/tests/snapshots/notification_request_openapi.json
+++ b/tests/snapshots/notification_request_openapi.json
@@ -104,17 +104,11 @@
             "type": "string"
           },
           "body_html": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "default": null,
             "description": "Optional HTML email body.",
-            "title": "Body Html"
+            "title": "Body Html",
+            "nullable": true,
+            "type": "string"
           },
           "priority": {
             "default": "normal",
@@ -169,17 +163,11 @@
             "type": "string"
           },
           "delivered_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "default": null,
             "description": "Delivery timestamp.",
-            "title": "Delivered At"
+            "title": "Delivered At",
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [

--- a/tests/snapshots/report_jobs_openapi.json
+++ b/tests/snapshots/report_jobs_openapi.json
@@ -223,30 +223,18 @@
             "type": "integer"
           },
           "download_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "default": null,
             "description": "Available when status=completed.",
-            "title": "Download Url"
+            "title": "Download Url",
+            "nullable": true,
+            "type": "string"
           },
           "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "default": null,
             "description": "Error message when status=failed.",
-            "title": "Error"
+            "title": "Error",
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [

--- a/tests/test_openapi_3_0_nullable.py
+++ b/tests/test_openapi_3_0_nullable.py
@@ -1,0 +1,318 @@
+"""Down-convert nested container nullability to valid OpenAPI 3.0 form (issue #562).
+
+OpenAPI 3.0 has no ``{"type": "null"}`` sentinel and cannot mark a ``$ref``
+nullable inline. Pydantic v2 emits ``Optional[T]`` as
+``{"anyOf": [<T>, {"type": "null"}]}`` and multi-type unions as
+``{"type": [..., "null"]}`` — both 3.1/2020-12 constructs. These tests pin the
+3.0 emit path so it rewrites those idioms to the 3.0 ``nullable: true`` form
+(``allOf`` wrapper for a nullable ``$ref``), while the 3.1 path stays faithful
+(locked by #558 / test_openapi_3_1.py).
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_openapi.decorator import clear_openapi_registry
+from azure_functions_openapi.registry import OpenAPIRegistry
+from azure_functions_openapi.spec import (
+    OPENAPI_VERSION_3_0,
+    OPENAPI_VERSION_3_1,
+    _collapse_nullable_combinator,
+    _convert_schema_to_3_0,
+    _convert_schemas_to_3_0,
+    generate_openapi_spec,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+def _iter_dicts(node: Any) -> Any:
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_dicts(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_dicts(item)
+
+
+def _has_null_type(node: Any) -> bool:
+    return any(d.get("type") == "null" for d in _iter_dicts(node))
+
+
+def _has_type_array(node: Any) -> bool:
+    return any(isinstance(d.get("type"), list) for d in _iter_dicts(node))
+
+
+# ---------------------------------------------------------------------------
+# _convert_schema_to_3_0 — scalar / union / enum
+# ---------------------------------------------------------------------------
+
+
+class TestConvertSchemaTo30Scalars:
+    def test_nullable_inline_scalar(self) -> None:
+        schema = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+
+        result = _convert_schema_to_3_0(schema)
+
+        assert result == {"type": "string", "nullable": True}
+        assert "anyOf" not in result
+
+    def test_type_array_single_non_null(self) -> None:
+        result = _convert_schema_to_3_0({"type": ["string", "null"]})
+
+        assert result == {"type": "string", "nullable": True}
+
+    def test_type_array_multi_non_null(self) -> None:
+        result = _convert_schema_to_3_0({"type": ["string", "integer", "null"]})
+
+        assert result["nullable"] is True
+        assert "type" not in result
+        assert result["anyOf"] == [{"type": "string"}, {"type": "integer"}]
+        assert not _has_null_type(result)
+        assert not _has_type_array(result)
+
+    def test_type_array_only_null(self) -> None:
+        result = _convert_schema_to_3_0({"type": ["null"]})
+
+        assert result["nullable"] is True
+        assert "type" not in result
+
+    def test_enum_with_null(self) -> None:
+        result = _convert_schema_to_3_0({"enum": [None, "a", "b"]})
+
+        assert result["enum"] == ["a", "b"]
+        assert result["nullable"] is True
+
+    def test_non_nullable_passthrough(self) -> None:
+        schema = {"type": "string", "description": "plain"}
+
+        assert _convert_schema_to_3_0(schema) == schema
+
+    def test_non_dict_passthrough(self) -> None:
+        assert _convert_schema_to_3_0("nope") == "nope"  # type: ignore[arg-type,comparison-overlap]
+
+
+# ---------------------------------------------------------------------------
+# _collapse_nullable_combinator — $ref / annotation / conflict
+# ---------------------------------------------------------------------------
+
+
+class TestCollapseNullableCombinator:
+    def test_nullable_ref_wraps_in_allof(self) -> None:
+        schema = {"anyOf": [{"$ref": "#/components/schemas/User"}, {"type": "null"}]}
+
+        result = _collapse_nullable_combinator(schema)
+
+        assert result == {
+            "nullable": True,
+            "allOf": [{"$ref": "#/components/schemas/User"}],
+        }
+        assert "anyOf" not in result
+
+    def test_nullable_ref_lifts_annotation_siblings(self) -> None:
+        schema = {
+            "anyOf": [
+                {"$ref": "#/components/schemas/User", "description": "the user"},
+                {"type": "null"},
+            ]
+        }
+
+        result = _collapse_nullable_combinator(schema)
+
+        assert result["allOf"] == [{"$ref": "#/components/schemas/User"}]
+        assert result["description"] == "the user"
+        assert result["nullable"] is True
+
+    def test_existing_annotation_wins_over_member(self) -> None:
+        schema = {
+            "description": "outer",
+            "anyOf": [{"type": "string", "description": "inner"}, {"type": "null"}],
+        }
+
+        result = _collapse_nullable_combinator(schema)
+
+        # Existing node annotation is preserved (setdefault semantics).
+        assert result["description"] == "outer"
+        assert result["type"] == "string"
+        assert result["nullable"] is True
+
+    def test_structural_conflict_keeps_combinator(self) -> None:
+        # Wrapper already has a (different) ``type`` — an ambiguous structural
+        # overlap must not be silently merged away.
+        schema = {"type": "object", "anyOf": [{"type": "string"}, {"type": "null"}]}
+
+        result = _collapse_nullable_combinator(schema)
+
+        assert result["nullable"] is True
+        assert result["anyOf"] == [{"type": "string"}]
+        assert result["type"] == "object"
+
+    def test_multiple_non_null_members_keep_combinator(self) -> None:
+        schema = {"anyOf": [{"type": "string"}, {"type": "integer"}, {"type": "null"}]}
+
+        result = _collapse_nullable_combinator(schema)
+
+        assert result["nullable"] is True
+        assert result["anyOf"] == [{"type": "string"}, {"type": "integer"}]
+
+    def test_no_null_member_unchanged(self) -> None:
+        schema = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+
+        assert _collapse_nullable_combinator(schema) == schema
+
+
+# ---------------------------------------------------------------------------
+# _convert_schema_to_3_0 — nested containers
+# ---------------------------------------------------------------------------
+
+
+class TestConvertSchemaTo30Nested:
+    def test_list_of_optional_ref(self) -> None:
+        schema = {
+            "type": "array",
+            "items": {"anyOf": [{"$ref": "#/components/schemas/User"}, {"type": "null"}]},
+        }
+
+        result = _convert_schema_to_3_0(schema)
+
+        assert result["type"] == "array"
+        assert result["items"] == {
+            "nullable": True,
+            "allOf": [{"$ref": "#/components/schemas/User"}],
+        }
+        assert not _has_null_type(result)
+
+    def test_optional_list(self) -> None:
+        schema = {
+            "anyOf": [
+                {"type": "array", "items": {"type": "string"}},
+                {"type": "null"},
+            ]
+        }
+
+        result = _convert_schema_to_3_0(schema)
+
+        assert result["type"] == "array"
+        assert result["items"] == {"type": "string"}
+        assert result["nullable"] is True
+
+    def test_dict_of_optional(self) -> None:
+        schema = {
+            "type": "object",
+            "additionalProperties": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        }
+
+        result = _convert_schema_to_3_0(schema)
+
+        assert result["additionalProperties"] == {"type": "string", "nullable": True}
+        assert not _has_null_type(result)
+
+    def test_optional_dict(self) -> None:
+        schema = {
+            "anyOf": [
+                {"type": "object", "additionalProperties": {"type": "integer"}},
+                {"type": "null"},
+            ]
+        }
+
+        result = _convert_schema_to_3_0(schema)
+
+        assert result["type"] == "object"
+        assert result["additionalProperties"] == {"type": "integer"}
+        assert result["nullable"] is True
+
+    def test_nested_defs_converted(self) -> None:
+        schema = {
+            "type": "object",
+            "$defs": {
+                "Child": {
+                    "type": "object",
+                    "properties": {"n": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
+                }
+            },
+        }
+
+        result = _convert_schema_to_3_0(schema)
+
+        assert result["$defs"]["Child"]["properties"]["n"] == {
+            "type": "string",
+            "nullable": True,
+        }
+
+    def test_convert_schemas_maps_all(self) -> None:
+        schemas = {
+            "A": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            "B": {"type": "integer"},
+        }
+
+        result = _convert_schemas_to_3_0(schemas)
+
+        assert result["A"] == {"type": "string", "nullable": True}
+        assert result["B"] == {"type": "integer"}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — list[Optional[User]] response under 3.0 vs 3.1
+# ---------------------------------------------------------------------------
+
+
+class User(BaseModel):
+    id: str
+    name: str
+
+
+def _list_optional_user_spec(version: str) -> dict[str, Any]:
+    reg = OpenAPIRegistry()
+    reg.set(
+        "list_users",
+        {
+            "route": "users",
+            "method": "get",
+            "summary": "List users",
+            "response": {
+                200: {
+                    "description": "ok",
+                    "content": {"application/json": {"schema": List[Optional[User]]}},
+                }
+            },
+        },
+    )
+    return generate_openapi_spec(openapi_version=version, registry=reg)
+
+
+def _response_schema(spec: dict[str, Any]) -> dict[str, Any]:
+    op = spec["paths"]["/api/users"]["get"]
+    schema: dict[str, Any] = op["responses"]["200"]["content"]["application/json"]["schema"]
+    return schema
+
+
+class TestListOptionalUserEndToEnd:
+    def test_30_is_null_free_and_valid(self) -> None:
+        spec = _list_optional_user_spec(OPENAPI_VERSION_3_0)
+
+        schema = _response_schema(spec)
+        assert schema["type"] == "array"
+        items = schema["items"]
+        assert items.get("nullable") is True
+        assert items["allOf"] == [{"$ref": "#/components/schemas/User"}]
+
+        # No 3.1-only constructs leak into a 3.0 document.
+        assert not _has_null_type(spec)
+        assert not _has_type_array(spec)
+
+    def test_31_preserves_faithful_anyof(self) -> None:
+        spec = _list_optional_user_spec(OPENAPI_VERSION_3_1)
+
+        items = _response_schema(spec)["items"]
+        assert "anyOf" in items
+        assert {"type": "null"} in items["anyOf"]

--- a/tests/test_spec_hoist_versions.py
+++ b/tests/test_spec_hoist_versions.py
@@ -7,10 +7,11 @@ the interaction between hoisting and the 3.0-vs-3.1 emit path so a regression
 cannot silently leak a raw ``$defs`` block (invalid in both versions) or a
 3.1-only construct into a 3.0 document.
 
-Design note (see #215): the 3.0 path does **not** down-convert Pydantic-v2
-nullable patterns to ``nullable: true`` — it emits a *compatibility warning*
-via ``_check_schemas_3_0_compatible`` (and raises in ``strict`` mode). The 3.1
-path preserves the 2020-12 ``anyOf`` + ``{"type": "null"}`` nullable syntax.
+Design note (see #562): the 3.0 path **down-converts** Pydantic-v2 nullable
+patterns (``anyOf`` containing ``{"type": "null"}``) to valid OpenAPI 3.0
+``nullable: true`` form — it does *not* warn or leak a 3.1-only construct, and
+this holds in ``strict`` mode too. The 3.1 path preserves the 2020-12 ``anyOf``
++ ``{"type": "null"}`` nullable syntax.
 """
 
 from __future__ import annotations
@@ -185,11 +186,11 @@ def test_hoisted_defs_30_no_defs_leak_and_refs_resolve(
 
 
 # ---------------------------------------------------------------------------
-# 3.0 — nullable hoisted defs → compatibility warning, still no leak
+# 3.0 — nullable hoisted defs → down-converted to nullable:true, no leak
 # ---------------------------------------------------------------------------
 
 
-def test_hoisted_nullable_defs_30_warns_without_leak(
+def test_hoisted_nullable_defs_30_downconverts_without_leak(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     scan_endpoint_metadata(_make_app(NULLABLE_DEFS_BODY))
@@ -201,18 +202,26 @@ def test_hoisted_nullable_defs_30_warns_without_leak(
     assert not _has_defs_key(spec)
     assert "Child" in spec["components"]["schemas"]
 
-    # The nullable construct is surfaced as a 3.0 compatibility warning
-    # (design #215: warn, do not silently down-convert).
-    assert any("3.0 compatibility" in m and "Child" in m for m in caplog.messages), caplog.messages
+    # The nullable construct is down-converted to valid 3.0 ``nullable: true``
+    # form (design #562: down-convert, do not warn or leak a 3.1-only construct).
+    nickname = spec["components"]["schemas"]["Child"]["properties"]["nickname"]
+    assert nickname == {"type": "string", "nullable": True}
+    assert "anyOf" not in nickname
+    assert not any("type" in d and d.get("type") == "null" for d in _iter_dicts(spec))
+
+    # No 3.0 compatibility warning is emitted for a successfully converted schema.
+    assert not any("3.0 compatibility" in m for m in caplog.messages), caplog.messages
 
 
-def test_hoisted_nullable_defs_30_strict_raises() -> None:
-    from azure_functions_openapi.exceptions import OpenAPISpecConfigError
-
+def test_hoisted_nullable_defs_30_strict_does_not_raise() -> None:
     scan_endpoint_metadata(_make_app(NULLABLE_DEFS_BODY))
 
-    with pytest.raises(OpenAPISpecConfigError, match="3.1-only constructs"):
-        generate_openapi_spec(openapi_version="3.0.0", strict=True)
+    # strict mode must not raise: the nullable pattern is a valid, convertible
+    # 3.0 construct (design #562), not a compatibility failure.
+    spec = generate_openapi_spec(openapi_version="3.0.0", strict=True)
+
+    nickname = spec["components"]["schemas"]["Child"]["properties"]["nickname"]
+    assert nickname == {"type": "string", "nullable": True}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_spec_validity.py
+++ b/tests/test_spec_validity.py
@@ -8,6 +8,7 @@ dicts that match our expectations. This catches subtle schema incompatibilities
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from openapi_spec_validator import validate
@@ -275,11 +276,10 @@ class TestSpecValidity30:
 
 
 class TestPydanticV2Compat30:
-    """Test that Pydantic v2 models with nullable fields warn/error in 3.0 mode."""
+    """Pydantic v2 models with nullable fields down-convert to valid 3.0 (#562)."""
 
-    def test_nullable_model_3_0_strict_raises(self) -> None:
-        """Strict mode raises when Pydantic nullable schema targets 3.0."""
-        from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+    def test_nullable_model_3_0_strict_downconverts(self) -> None:
+        """Strict mode down-converts Pydantic nullable schema to valid 3.0 (#562)."""
 
         @openapi(
             route="/users",
@@ -290,17 +290,30 @@ class TestPydanticV2Compat30:
         def create_user() -> None:
             pass
 
-        with pytest.raises(OpenAPISpecConfigError, match="3.1-only constructs"):
-            generate_openapi_spec(
-                title="Test",
-                version="1.0.0",
-                openapi_version="3.0.0",
-                route_prefix="",
-                strict=True,
-            )
+        # #562: nullable fields are down-converted to ``nullable: true`` form,
+        # so strict mode produces a valid 3.0 document instead of raising.
+        spec = generate_openapi_spec(
+            title="Test",
+            version="1.0.0",
+            openapi_version="3.0.0",
+            route_prefix="",
+            strict=True,
+        )
+        assert spec["openapi"] == "3.0.0"
+        props = spec["components"]["schemas"]["NullableModel"]["properties"]
+        nickname = props["nickname"]
+        assert nickname["type"] == "string"
+        assert nickname["nullable"] is True
+        assert "anyOf" not in nickname
+        score = props["score"]
+        assert score["type"] == "integer"
+        assert score["nullable"] is True
+        assert "anyOf" not in score
+        # No 3.1-only null sentinel leaks into the 3.0 document.
+        assert '"type": "null"' not in json.dumps(spec)
 
     def test_nullable_model_3_0_non_strict_warns(self) -> None:
-        """Non-strict mode warns but still generates (potentially invalid) spec."""
+        """Non-strict mode also down-converts and generates a valid 3.0 spec."""
 
         @openapi(
             route="/users",
@@ -311,7 +324,7 @@ class TestPydanticV2Compat30:
         def create_user() -> None:
             pass
 
-        # Non-strict: should not raise, just log a warning
+        # Non-strict: down-converts to valid 3.0 (no raise, no warning)
         spec = generate_openapi_spec(
             title="Test",
             version="1.0.0",


### PR DESCRIPTION
## Summary
- Under `openapi_version="3.0.0"`, Pydantic v2 nullability idioms (`anyOf: [T, {type: null}]` and `type: [..., "null"]`) leaked through unchanged, producing **invalid** 3.0 documents for nested containers like `list[Optional[User]]`.
- Adds a recursive 3.0 down-converter (mirror of the existing 3.1 converter) that rewrites those to the 3.0 `nullable: true` form and wires it into `generate_openapi_spec` for both operation and component schemas, before the 3.0 compatibility check.
- The 3.1 path is untouched and stays faithful to 2020-12 syntax (locked by #558). 3.1 snapshots are byte-identical.

## Conversion rules
- nullable `$ref` → `allOf: [<bare ref>]` + `nullable: true` (annotation siblings lifted up)
- nullable inline scalar → member keys merged up (existing annotations win) + `nullable: true`
- multi-type / structurally-conflicting unions → keep combinator (null member dropped) + `nullable: true`
- `type: [T, "null"]` → `type: T` (or `anyOf` for multi-type) + `nullable: true`
- `enum: [null, ...]` → drop null member + `nullable: true`

## Design change (reverses #215 for the 3.0 path)
Nullable Pydantic schemas now **down-convert** on the 3.0 path — silently, and in `strict` mode too — instead of warning/raising a "3.1-only constructs" error. Approach validated with Oracle (multi-type array collapse, `allOf`+`nullable` for refs, conservative conflict-guarded up-merge, enum null-strip).

## Tests
- New `tests/test_openapi_3_0_nullable.py`: unit tests for `_convert_schema_to_3_0` / `_collapse_nullable_combinator` (scalars, unions, enums, `$ref`, annotation/structural conflicts, nested `list`/`dict`/`$defs`) + end-to-end `list[Optional[User]]` (3.0 null-free `allOf`+`nullable`; 3.1 faithful `anyOf`).
- Reversed the two #215 tests in `test_spec_hoist_versions.py` and the strict-raises test in `test_spec_validity.py`.
- Regenerated the 3.0 snapshots (now null-free); 3.1 snapshots unchanged.
- `make lint`, `make typecheck`, `make lint-workflows` clean. Full suite: 898 passed, 6 skipped. Coverage 95.34% (≥95%).

Closes #562