### PR TITLE
docs(agents): forbid cross-repo umbrella issues (single-repo boundary)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,12 @@ What problem this issue addresses and why now. Note the target release (e.g. vX.
 
 When splitting a large piece of work into focused issues, keep the umbrella open as a tracker that links each child issue with a checkbox; close it once every child is closed or explicitly deferred.
 
+**Single-repo boundary (non-negotiable).** An umbrella issue may only track child issues **in this same repository**. Do **not** open a tracker here that coordinates, checklists, or drives work in sibling repos (`azure-functions-validation-python`, `azure-functions-logging-python`, etc.), and do **not** ask another repo to host a tracker for this one. Each repository in the DX Toolkit is operated **independently** — it owns its own backlog, fix, verification, and release cadence.
+
+- A bug that also exists in sibling repos is **not** one shared work item — it is N independent per-repo issues. File (or ask the maintainer to file) a separate issue in each affected repo; fix and release each on its own timeline.
+- Cross-repo audit findings may be **referenced** from a local issue for context (a plain link is fine), but the local issue must be closeable on this repo's work alone. Never leave an issue here open pending another repo's fix.
+- If you catch yourself building a checklist of `owner/other-repo#N` items to "drive from here," stop — that is the cross-repo umbrella anti-pattern. Close it as `not planned` and let each repo track its own child issue.
+
 ### Project management model
 
 This repository is **issue-based, not milestone-based**. Track and group work using issues plus the existing label taxonomy — do **not** introduce parallel structures.


### PR DESCRIPTION
## Summary
- Codify a **single-repo boundary** in `AGENTS.md` "Umbrella issues": an umbrella may only track child issues in *this* repo.
- Clarify that a bug shared across sibling repos is N independent per-repo issues, not one shared work item.
- Allow *referencing* cross-repo audit findings for context, but require the local issue to be closeable on this repo's work alone.
- Name the cross-repo umbrella anti-pattern and instruct closing such trackers as `not planned`.

## Motivation
Closing the fleet-wide CI umbrella #559 surfaced that hosting a cross-repo tracker here couples independent release timelines and leaves this repo's issue open pending another repo's work. Each DX Toolkit repo runs independently.

Closes #570