### PR TITLE
chore: codify open issue-creation as fleet policy (#575)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,10 @@ When splitting a large piece of work into focused issues, keep the umbrella open
 - Cross-repo audit findings may be **referenced** from a local issue for context (a plain link is fine), but the local issue must be closeable on this repo's work alone. Never leave an issue here open pending another repo's fix.
 - If you catch yourself building a checklist of `owner/other-repo#N` items to "drive from here," stop — that is the cross-repo umbrella anti-pattern. Close it as `not planned` and let each repo track its own child issue.
 
+### Issue-creation access (fleet policy)
+
+Keep issue creation **open/unrestricted** on every public toolkit repository (issue tracker enabled, no `interaction-limits`). External bug reports are the only inbound support channel, so restricting issue creation suppresses the signal we most need. Do not enable an interaction limit or restrict issue creation without an explicit, documented reason recorded in an issue first.
+
 ### Project management model
 
 This repository is **issue-based, not milestone-based**. Track and group work using issues plus the existing label taxonomy — do **not** introduce parallel structures.


### PR DESCRIPTION
## Summary
Resolves #575.

- **Confirmed setting:** this repo has **no interaction limit** (`GET /repos/.../interaction-limits` → `{}`) and the issue tracker is enabled — issue creation is already **open/unrestricted**.
- **Decision:** keep it open. External bug reports are the only inbound support channel; restricting issue creation suppresses the signal we most need.
- **Promoted to fleet convention:** added an "Issue-creation access (fleet policy)" section to `AGENTS.md` (single source of truth), matching the canonical wording landed in `azure-functions-logging-python`, so every repo lands on the identical conclusion.

## Verification
- `gh api repos/yeongseon/azure-functions-openapi-python/interaction-limits` → `{}` (unrestricted).
- AGENTS.md-only change; no code or runtime impact.

Closes #575