### PR TITLE
ci: harden and wire the hatch default-env-pin lint (canonical source)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           python tools/lint_release_workflows.py
           python tools/lint_workflow_pins.py
+          python tools/lint_hatch_matrix.py
 
       - name: Ruff style check
         run: ruff check src tests

--- a/tests/test_hatch_matrix_lint.py
+++ b/tests/test_hatch_matrix_lint.py
@@ -1,8 +1,11 @@
-"""Regression guard for the hatch-pin / CI-matrix conflict lint (#559).
+"""Regression guard for the hatch-pin / CI-matrix conflict lint.
+
+Origin of the fleet-wide fix: #554 / PR #555 (CI hardening tracked in #559);
+fleet deployment audit in #576. This repo is the canonical source for the lint.
 
 Exercises tools/lint_hatch_matrix.py against this repo (must be clean -- the
-reference fix in #555 runs the matrix directly on the interpreter and adds a
-version guard) and against synthetic buggy configs (must be caught).
+test matrix runs directly on the interpreter and adds a version guard) and
+against synthetic buggy configs (must be caught).
 """
 
 from __future__ import annotations
@@ -46,7 +49,7 @@ jobs:
 
 
 def test_repo_is_clean() -> None:
-    """This repo's committed workflows must pass -- the fix (#555) is in place."""
+    """This repo's committed workflows must pass -- the fix is in place."""
     assert lint_mod.lint() == []
 
 
@@ -113,8 +116,10 @@ jobs:
     assert lint_mod.check_workflow(text, "ci.yml", _PINNED) == []
 
 
-def test_interpreter_guard_makes_it_clean() -> None:
-    # Routes through hatch but proves the interpreter matches the matrix cell.
+def test_interpreter_guard_alone_is_not_enough() -> None:
+    # Routes tests through hatch (hatch run pytest) with only a version_info
+    # guard. The guard asserts the top-level interpreter, but the tests still
+    # run on the pinned hatch env -- so this must be FLAGGED, not cleared.
     text = (
         _MATRIX_BLOCK
         + """
@@ -125,4 +130,5 @@ def test_interpreter_guard_makes_it_clean() -> None:
         # version_info guard tied to matrix.python-version
 """
     )
-    assert lint_mod.check_workflow(text, "ci.yml", _PINNED) == []
+    errors = lint_mod.check_workflow(text, "ci.yml", _PINNED)
+    assert errors and "runs tests through Hatch" in errors[0]

--- a/tools/lint_hatch_matrix.py
+++ b/tools/lint_hatch_matrix.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Guard against the fleet-wide "hatch default-env pin hides the CI matrix" bug.
 
-Follow-up to the CI hardening tracked in #559 (reference fix: #554 / PR #555).
+Origin of the fleet-wide fix: #554 / PR #555 (CI hardening tracked in #559);
+fleet deployment audit in #576. This repo is the canonical source for the lint.
 
 The failure mode this lint catches: a repo pins its Hatch *default* env to a
 single interpreter --
@@ -26,11 +27,13 @@ Rule -- a workflow is flagged when ALL of the following hold:
 3. that workflow routes the test run through Hatch (``hatch run`` or a
    ``make`` target known to wrap Hatch: ``install`` / ``check-all`` /
    ``check`` / ``test`` / ``coverage``); and
-4. the workflow does NOT carry an interpreter-match guard -- a step that
-   asserts the runtime ``sys.version_info`` equals ``matrix.python-version``
-   (the belt-and-braces assertion added by the reference fix). A repo that
-   runs tests directly on the matrix interpreter (``python -m pytest``) or
-   proves the interpreter with such a guard is considered safe.
+4. the workflow does NOT run its tests directly on the matrix interpreter --
+   i.e. there is no un-Hatched ``pytest`` / ``python -m pytest`` invocation.
+   A ``sys.version_info`` guard is NOT sufficient on its own: it asserts the
+   top-level interpreter, but a subsequent ``hatch run pytest`` still
+   re-resolves to the pinned env, so the guard cannot prove where the tests
+   actually ran. Only a direct pytest invocation on the matrix interpreter
+   makes the workflow safe.
 
 Stdlib-only on purpose (mirrors ``tools/lint_workflow_pins.py``): the lint must
 not itself depend on a package that can drift. Exit code 0 = clean, 1 = drift.
@@ -59,9 +62,9 @@ _SECTION_RE = re.compile(r"^\s*\[")
 _HATCH_RUN_RE = re.compile(r"\bhatch\s+run\b")
 _HATCH_MAKE_RE = re.compile(r"\bmake\s+(?:" + "|".join(_HATCH_MAKE_TARGETS) + r")\b")
 
-# An interpreter-match guard proves the runtime interpreter equals the matrix cell.
-_GUARD_VERSION_INFO_RE = re.compile(r"\bversion_info\b")
-_GUARD_MATRIX_REF_RE = re.compile(r"matrix\.python-version")
+# A direct pytest invocation (``python -m pytest`` / ``pytest ...``) that is not
+# routed through Hatch proves the tests run on the matrix interpreter itself.
+_DIRECT_PYTEST_RE = re.compile(r"\bpytest\b")
 
 # Inline matrix list: python-version: ["3.10", "3.11"].
 _MATRIX_INLINE_RE = re.compile(r"""python-version:\s*\[(?P<body>[^\]]*)\]""")
@@ -138,11 +141,22 @@ def routes_tests_through_hatch(workflow_text: str) -> bool:
     return bool(_HATCH_RUN_RE.search(workflow_text) or _HATCH_MAKE_RE.search(workflow_text))
 
 
-def has_interpreter_guard(workflow_text: str) -> bool:
-    """True when the workflow asserts the runtime interpreter matches the matrix cell."""
-    return bool(
-        _GUARD_VERSION_INFO_RE.search(workflow_text) and _GUARD_MATRIX_REF_RE.search(workflow_text)
-    )
+def runs_tests_directly_on_matrix(workflow_text: str) -> bool:
+    """True when the workflow invokes pytest directly (not through ``hatch run``).
+
+    The interpreter provisioned by ``actions/setup-python`` is then the one that
+    executes the tests, so the matrix cell is genuinely exercised. A mere
+    ``sys.version_info`` guard is NOT sufficient: it asserts the *top-level*
+    interpreter but a subsequent ``hatch run pytest`` still re-resolves to the
+    pinned Hatch env, so the guard cannot prove where the tests actually ran.
+    """
+    for raw in workflow_text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if _DIRECT_PYTEST_RE.search(line) and "hatch" not in line and "make " not in line:
+            return True
+    return False
 
 
 def check_workflow(workflow_text: str, rel_path: str, pinned: dict[str, str]) -> list[str]:
@@ -154,7 +168,10 @@ def check_workflow(workflow_text: str, rel_path: str, pinned: dict[str, str]) ->
         return []
     if not routes_tests_through_hatch(workflow_text):
         return []
-    if has_interpreter_guard(workflow_text):
+    if runs_tests_directly_on_matrix(workflow_text):
+        # Hatch may still run interpreter-agnostic linters, but the test suite
+        # executes via a direct pytest invocation on the matrix interpreter, so
+        # every cell is genuinely exercised.
         return []
     env_desc = ", ".join(f"{name}={ver}" for name, ver in sorted(pinned.items()))
     return [
@@ -162,7 +179,7 @@ def check_workflow(workflow_text: str, rel_path: str, pinned: dict[str, str]) ->
         f"but [tool.hatch.envs] pins the interpreter ({env_desc}); every matrix "
         f"cell would execute on the pinned version. Run tests directly on the "
         f"matrix interpreter (python -m pytest) or add a sys.version_info guard "
-        f"asserting it equals matrix.python-version (see #559)."
+        f"asserting it equals matrix.python-version."
     ]
 
 


### PR DESCRIPTION
## Context

The fleet-wide audit (#576) upgraded every sibling repo to the **hardened** `lint_hatch_matrix.py` — one where a bare `sys.version_info` guard is no longer accepted as proof; a workflow must invoke pytest **directly** (not through `hatch run`), the only signal that proves where the tests actually ran.

But this repo — the **origin** of the lint (#554 / PR #555) and the host of the audit — was itself left on the older, weaker version. Its lint was also only referenced from the `make lint-workflows` Makefile target, which **no workflow calls**, so it gave zero PR-time protection.

## Changes

- Replace `tools/lint_hatch_matrix.py` + `tests/test_hatch_matrix_lint.py` with the hardened version, keeping this repo's canonical-source framing in the header.
- Wire `python tools/lint_hatch_matrix.py` into the CI quality job's "Lint workflows" step alongside the existing release/pin linters.
- The test matrix already runs raw pytest on the matrix interpreter, so the repo is clean under the stricter rule.

## Verification

- `python tools/lint_hatch_matrix.py` → exit 0
- `pytest tests/test_hatch_matrix_lint.py` → 13 passed
- ruff / ruff-format / mypy clean on both files

Refs #576, #559